### PR TITLE
feat: Remove start and end time options

### DIFF
--- a/ts2mp4/cli.py
+++ b/ts2mp4/cli.py
@@ -7,8 +7,6 @@ from ts2mp4.ts2mp4 import ts2mp4
 def cli():
     parser = argparse.ArgumentParser()
     parser.add_argument("path", type=Path)
-    parser.add_argument("-ss", type=str, default=None)
-    parser.add_argument("-to", type=str, default=None)
     args = parser.parse_args()
 
-    ts2mp4(ts=args.path, ss=args.ss, to=args.to)
+    ts2mp4(ts=args.path)

--- a/ts2mp4/ts2mp4.py
+++ b/ts2mp4/ts2mp4.py
@@ -1,31 +1,8 @@
-import re
 import subprocess
 from pathlib import Path
-from typing import Optional
 
 
-def _parse_duration_expression(dur_expr: str) -> float:
-    match = re.fullmatch(
-        r"(((?P<hour>\d+):)?(?P<minute>[0-5]?[0-9]):)?(?P<second>[0-5]?[0-9](\.(?P<microsecond>\d+))?)",
-        dur_expr,
-    )
-
-    if not match:
-        raise ValueError
-
-    return (
-        int(match.group("hour") or 0) * 3600
-        + int(match.group("minute") or 0) * 60
-        + float(match.group("second"))
-    )
-
-
-def ts2mp4(ts: Path, ss: Optional[str], to: Optional[str]):
-    ss_ = _parse_duration_expression(ss) if ss else None
-    to_ = _parse_duration_expression(to) if to else None
-    if ss_ and to_:
-        to_ -= ss_
-
+def ts2mp4(ts: Path):
     ts = ts.resolve()
     mp4 = ts.with_suffix(".mp4")
     mp4_part = ts.with_suffix(".mp4.part")
@@ -34,37 +11,29 @@ def ts2mp4(ts: Path, ss: Optional[str], to: Optional[str]):
         return
 
     proc = subprocess.run(
-        args=(
-            [
-                "ffmpeg",
-                "-fflags",
-                "+discardcorrupt",
-                "-y",
-            ]
-            + (["-ss", str(ss_)] if ss_ else [])
-            + [
-                "-i",
-                str(ts),
-                "-f",
-                "mp4",
-                "-vsync",
-                "1",
-                "-vf",
-                "bwdif",
-                "-codec:v",
-                "libx265",
-                "-crf",
-                "22",
-                "-codec:a",
-                "copy",
-                "-bsf:a",
-                "aac_adtstoasc",
-            ]
-            + (["-to", str(to_)] if to_ else [])
-            + [
-                str(mp4_part),
-            ]
-        )
+        args=[
+            "ffmpeg",
+            "-fflags",
+            "+discardcorrupt",
+            "-y",
+            "-i",
+            str(ts),
+            "-f",
+            "mp4",
+            "-vsync",
+            "1",
+            "-vf",
+            "bwdif",
+            "-codec:v",
+            "libx265",
+            "-crf",
+            "22",
+            "-codec:a",
+            "copy",
+            "-bsf:a",
+            "aac_adtstoasc",
+            str(mp4_part),
+        ]
     )
 
     if proc.returncode == 0:


### PR DESCRIPTION
This commit removes the command-line options `-ss` and `-to`, which allowed specifying start and end times for the conversion. The functionality has been removed from both the CLI and the core `ts2mp4` function to simplify the tool.
