### PR TITLE
feat: Add tests for CLI and integrate into CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,3 +39,6 @@ jobs:
 
       - name: Check types with mypy
         run: poetry run mypy .
+
+      - name: Run tests with pytest
+        run: poetry run pytest

--- a/poetry.lock
+++ b/poetry.lock
@@ -72,11 +72,30 @@ description = "Cross-platform colored terminal text."
 optional = false
 python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,!=3.5.*,!=3.6.*,>=2.7"
 groups = ["main", "dev"]
-markers = "platform_system == \"Windows\""
 files = [
     {file = "colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6"},
     {file = "colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44"},
 ]
+markers = {main = "platform_system == \"Windows\"", dev = "platform_system == \"Windows\" or sys_platform == \"win32\""}
+
+[[package]]
+name = "exceptiongroup"
+version = "1.3.0"
+description = "Backport of PEP 654 (exception groups)"
+optional = false
+python-versions = ">=3.7"
+groups = ["dev"]
+markers = "python_version < \"3.11\""
+files = [
+    {file = "exceptiongroup-1.3.0-py3-none-any.whl", hash = "sha256:4d111e6e0c13d0644cad6ddaa7ed0261a0b36971f6d23e7ec9b4b9097da78a10"},
+    {file = "exceptiongroup-1.3.0.tar.gz", hash = "sha256:b241f5885f560bc56a59ee63ca4c6a8bfa46ae4ad651af316d4e81817bb9fd88"},
+]
+
+[package.dependencies]
+typing-extensions = {version = ">=4.6.0", markers = "python_version < \"3.13\""}
+
+[package.extras]
+test = ["pytest (>=6)"]
 
 [[package]]
 name = "flake8"
@@ -94,6 +113,18 @@ files = [
 mccabe = ">=0.7.0,<0.8.0"
 pycodestyle = ">=2.14.0,<2.15.0"
 pyflakes = ">=3.4.0,<3.5.0"
+
+[[package]]
+name = "iniconfig"
+version = "2.1.0"
+description = "brain-dead simple config-ini parsing"
+optional = false
+python-versions = ">=3.8"
+groups = ["dev"]
+files = [
+    {file = "iniconfig-2.1.0-py3-none-any.whl", hash = "sha256:9deba5723312380e77435581c6bf4935c94cbfab9b1ed33ef8d238ea168eb760"},
+    {file = "iniconfig-2.1.0.tar.gz", hash = "sha256:3abbd2e30b36733fee78f9c7f7308f2d0050e88f0087fd25c2645f63c773e1c7"},
+]
 
 [[package]]
 name = "isort"
@@ -262,6 +293,22 @@ docs = ["furo (>=2023.7.26)", "proselint (>=0.13)", "sphinx (>=7.1.1)", "sphinx-
 test = ["appdirs (==1.4.4)", "covdefaults (>=2.3)", "pytest (>=7.4)", "pytest-cov (>=4.1)", "pytest-mock (>=3.11.1)"]
 
 [[package]]
+name = "pluggy"
+version = "1.6.0"
+description = "plugin and hook calling mechanisms for python"
+optional = false
+python-versions = ">=3.9"
+groups = ["dev"]
+files = [
+    {file = "pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746"},
+    {file = "pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3"},
+]
+
+[package.extras]
+dev = ["pre-commit", "tox"]
+testing = ["coverage", "pytest", "pytest-benchmark"]
+
+[[package]]
 name = "pycodestyle"
 version = "2.14.0"
 description = "Python style guide checker"
@@ -309,7 +356,7 @@ version = "2.19.2"
 description = "Pygments is a syntax highlighting package written in Python."
 optional = false
 python-versions = ">=3.8"
-groups = ["main"]
+groups = ["main", "dev"]
 files = [
     {file = "pygments-2.19.2-py3-none-any.whl", hash = "sha256:86540386c03d588bb81d44bc3928634ff26449851e99741617ecb9037ee5ec0b"},
     {file = "pygments-2.19.2.tar.gz", hash = "sha256:636cb2477cec7f8952536970bc533bc43743542f70392ae026374600add5b887"},
@@ -317,6 +364,30 @@ files = [
 
 [package.extras]
 windows-terminal = ["colorama (>=0.4.6)"]
+
+[[package]]
+name = "pytest"
+version = "8.4.1"
+description = "pytest: simple powerful testing with Python"
+optional = false
+python-versions = ">=3.9"
+groups = ["dev"]
+files = [
+    {file = "pytest-8.4.1-py3-none-any.whl", hash = "sha256:539c70ba6fcead8e78eebbf1115e8b589e7565830d7d006a8723f19ac8a0afb7"},
+    {file = "pytest-8.4.1.tar.gz", hash = "sha256:7c67fd69174877359ed9371ec3af8a3d2b04741818c51e5e99cc1742251fa93c"},
+]
+
+[package.dependencies]
+colorama = {version = ">=0.4", markers = "sys_platform == \"win32\""}
+exceptiongroup = {version = ">=1", markers = "python_version < \"3.11\""}
+iniconfig = ">=1"
+packaging = ">=20"
+pluggy = ">=1.5,<2"
+pygments = ">=2.7.2"
+tomli = {version = ">=1", markers = "python_version < \"3.11\""}
+
+[package.extras]
+dev = ["argcomplete", "attrs (>=19.2)", "hypothesis (>=3.56)", "mock", "requests", "setuptools", "xmlschema"]
 
 [[package]]
 name = "rich"
@@ -408,4 +479,4 @@ files = [
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.9"
-content-hash = "dfc1c0257637824e74eaafc0f5aef7c7531469b7b940c5b32b7bf4dbddf1f999"
+content-hash = "6c5a0362e92a0cb3093d6d8b4cca921c6591856698395040e09f23a03b1f9236"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,7 @@ isort = {extras = ["pyproject"], version = "*"}
 flake8 = "^7.3.0"
 mypy = "*"
 pydocstyle = "*"
+pytest = "^8.4.1"
 
 [tool.poetry.scripts]
 ts2mp4 = "ts2mp4.cli:app"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,27 @@
+import subprocess
+
+
+def test_ts2mp4_help():
+    """Test that `ts2mp4 --help` runs without error."""
+    result = subprocess.run(
+        ["poetry", "run", "ts2mp4", "--help"], capture_output=True, text=True
+    )
+
+    # Check that the command exits successfully.
+    assert result.returncode == 0
+    # Check that the output contains the usage string to ensure the Typer CLI is running.
+    assert "Usage:" in result.stdout
+
+
+def test_python_m_ts2mp4_help():
+    """Test that `python -m ts2mp4 --help` runs without error."""
+    result = subprocess.run(
+        ["poetry", "run", "python", "-m", "ts2mp4", "--help"],
+        capture_output=True,
+        text=True,
+    )
+
+    # Check that the command exits successfully.
+    assert result.returncode == 0
+    # Check that the output contains the usage string to ensure the Typer CLI is running.
+    assert "Usage:" in result.stdout

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,25 +1,18 @@
 import subprocess
 
-
-def test_ts2mp4_help():
-    """Test that `ts2mp4 --help` runs without error."""
-    result = subprocess.run(
-        ["poetry", "run", "ts2mp4", "--help"], capture_output=True, text=True
-    )
-
-    # Check that the command exits successfully.
-    assert result.returncode == 0
-    # Check that the output contains the usage string to ensure the Typer CLI is running.
-    assert "Usage:" in result.stdout
+import pytest
 
 
-def test_python_m_ts2mp4_help():
-    """Test that `python -m ts2mp4 --help` runs without error."""
-    result = subprocess.run(
+@pytest.mark.parametrize(
+    "command",
+    [
+        ["poetry", "run", "ts2mp4", "--help"],
         ["poetry", "run", "python", "-m", "ts2mp4", "--help"],
-        capture_output=True,
-        text=True,
-    )
+    ],
+)
+def test_cli_entry_points_start_correctly(command):
+    """Test that CLI entry points run without error and show help message."""
+    result = subprocess.run(command, capture_output=True, text=True)
 
     # Check that the command exits successfully.
     assert result.returncode == 0

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -12,9 +12,7 @@ import pytest
 )
 def test_cli_entry_points_start_correctly(command):
     """Test that CLI entry points run without error and show help message."""
-    result = subprocess.run(command, capture_output=True, text=True)
+    result = subprocess.run(command, capture_output=True, text=True, check=True)
 
-    # Check that the command exits successfully.
-    assert result.returncode == 0
     # Check that the output contains the usage string to ensure the Typer CLI is running.
     assert "Usage:" in result.stdout


### PR DESCRIPTION
This commit introduces tests for the command-line interface to ensure that the entry points (`ts2mp4` and `python -m ts2mp4`) are working correctly.

- Adds `pytest` as a development dependency.
- Creates `tests/test_cli.py` to verify the CLI starts and shows the help message.
- Updates the CI workflow in `ci.yml` to run `pytest` on every push and pull request.
