### PR TITLE
feat: Add `make release` command for GitHub releases

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,3 +10,17 @@ $(TEST_ASSETS_DIR)/test_video.ts: Makefile
 		-codec:a aac \
 		$@
 	@echo "Dummy video '$@' generated successfully."
+
+release:
+	echo "Creating a new GitHub release..."
+	DATE=$$(date +%Y.%m.%d); \
+	LATEST_TAG=$$(git tag -l "$$DATE.*" | sort -V | tail -n 1); \
+	N=1; \
+	if [ -n "$$LATEST_TAG" ]; then \
+		LAST_N=$$(echo "$$LATEST_TAG" | sed 's/.*\.//'); \
+		N=$$(expr $$LAST_N + 1); \
+	fi; \
+	TAG="$$DATE.$$N"; \
+	echo "Generated tag: $$TAG"; \
+	gh release create "$$TAG" --generate-notes; \
+	echo "GitHub release created successfully with tag $$TAG."


### PR DESCRIPTION
This commit introduces a new `release` target to the Makefile.
This command automates the creation of GitHub releases using the `gh` CLI tool.

The release tag format is `yyyy.mm.dd.n`, where `n` starts from 1 for the first release of the day
and increments for subsequent releases on the same day.
Release notes are automatically generated by `gh`.
