### PR TITLE
feat: Use linuxserver/ffmpeg:latest container in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,7 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    container: linuxserver/ffmpeg:latest
     steps:
       - name: Checkout code
         uses: actions/checkout@v4.1.7
@@ -27,9 +28,6 @@ jobs:
 
       - name: Install dependencies
         run: poetry sync
-
-      - name: Install ffmpeg
-        run: sudo apt-get update && sudo apt-get install -y ffmpeg
 
       - name: Generate test assets
         run: make tests/assets/test_video.ts


### PR DESCRIPTION
This commit updates the CI workflow to use the `linuxserver/ffmpeg:latest` Docker container.
This change eliminates the need to install ffmpeg during the CI run,
which should significantly reduce the build time.
