### PR TITLE
feat: Use static ffmpeg build in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,8 +28,12 @@ jobs:
       - name: Install dependencies
         run: poetry sync
 
-      - name: Install ffmpeg
-        run: sudo apt-get update && sudo apt-get install -y ffmpeg
+      - name: Download and install ffmpeg static build
+        run: |
+          FFMPEG_URL="https://johnvansickle.com/ffmpeg/releases/ffmpeg-release-amd64-static.tar.xz"
+          curl -L $FFMPEG_URL -o ffmpeg-static.tar.xz
+          tar -xf ffmpeg-static.tar.xz
+          echo "$(pwd)/ffmpeg-*-amd64-static" >> $GITHUB_PATH
 
       - name: Generate test assets
         run: make tests/assets/test_video.ts


### PR DESCRIPTION
Replaced apt-get installation of ffmpeg with a static build download
and extraction in the CI workflow. This should reduce the CI build time.
