### PR TITLE
Refactor: Remove default crf and preset values from ts2mp4 function

### DIFF
--- a/tests/test_ts2mp4.py
+++ b/tests/test_ts2mp4.py
@@ -37,41 +37,6 @@ def mock_dependencies(mocker):
     return mock_subprocess_run
 
 
-def test_ts2mp4_default_crf_preset(mock_dependencies):
-    """Test ts2mp4 with default crf and preset values."""
-    ts_path = Path("test.ts")
-    ts2mp4(ts_path)
-    subprocess_run_mock = mock_dependencies
-    expected_command = [
-        "ffmpeg",
-        "-fflags",
-        "+discardcorrupt",
-        "-y",
-        "-i",
-        str(ts_path.resolve()),
-        "-f",
-        "mp4",
-        "-vsync",
-        "1",
-        "-vf",
-        "bwdif",
-        "-codec:v",
-        "libx265",
-        "-crf",
-        "22",  # Default CRF
-        "-preset",
-        "medium",  # Default preset
-        "-codec:a",
-        "copy",
-        "-bsf:a",
-        "aac_adtstoasc",
-        str(ts_path.with_suffix(".mp4.part")),
-    ]
-    subprocess_run_mock.assert_any_call(
-        args=expected_command, check=True, capture_output=True, text=True
-    )
-
-
 @pytest.mark.parametrize(
     "crf_value, preset_value",
     [

--- a/ts2mp4/ts2mp4.py
+++ b/ts2mp4/ts2mp4.py
@@ -16,7 +16,7 @@ def _get_ts2mp4_version() -> str:
         return "Unknown"
 
 
-def ts2mp4(ts: Path, crf: int = 22, preset: str = "medium"):
+def ts2mp4(ts: Path, crf: int, preset: str):
     start_time = datetime.datetime.now()
     logger.info(f"Conversion Log for {ts.name}")
     logger.info(f"Start Time: {start_time}")


### PR DESCRIPTION
Removed default values for `crf` and `preset` parameters in the `ts2mp4` function
in `ts2mp4/ts2mp4.py`. These values are now explicitly passed from `cli.py`.

Also removed the redundant `test_ts2mp4_default_crf_preset` from `tests/test_ts2mp4.py`
as its functionality is covered by `test_ts2mp4_custom_crf_preset` and the `ts2mp4`
function no longer has default values for these parameters.
