### PR TITLE
feature/default preset slow

### DIFF
--- a/ts2mp4/cli.py
+++ b/ts2mp4/cli.py
@@ -43,8 +43,8 @@ def main(
         int, typer.Option(help="CRF value for encoding. Defaults to 22.")
     ] = 22,
     preset: Annotated[
-        Preset, typer.Option(help="Encoding preset. Defaults to 'medium'.")
-    ] = Preset.medium,
+        Preset, typer.Option(help="Encoding preset. Defaults to 'slow'.")
+    ] = Preset.slow,
 ):
     if log_file is None:
         log_file = path.with_suffix(".log")


### PR DESCRIPTION
- **Refactor: Remove default crf and preset values from ts2mp4 function**
- **Feat: Change default preset to 'slow' in CLI**
