### PR TITLE
Feat: Change default preset to 'slow' in CLI

### DIFF
--- a/ts2mp4/cli.py
+++ b/ts2mp4/cli.py
@@ -43,8 +43,8 @@ def main(
         int, typer.Option(help="CRF value for encoding. Defaults to 22.")
     ] = 22,
     preset: Annotated[
-        Preset, typer.Option(help="Encoding preset. Defaults to 'medium'.")
-    ] = Preset.medium,
+        Preset, typer.Option(help="Encoding preset. Defaults to 'slow'.")
+    ] = Preset.slow,
 ):
     if log_file is None:
         log_file = path.with_suffix(".log")


### PR DESCRIPTION
Updated the default value for the `preset` option in `ts2mp4/cli.py`
from 'medium' to 'slow'. This makes 'slow' the default encoding preset
when using the `ts2mp4` command-line tool.
