### PR TITLE
Refactor: `ts2mp4` function and related components

### DIFF
--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -21,6 +21,9 @@ def test_cli_entry_points_start_correctly(command):
 def test_cli_options_recognized(mocker, tmp_path):
     """Test that the CLI recognizes the --crf and --preset options."""
     mock_ts2mp4 = mocker.patch("ts2mp4.ts2mp4.ts2mp4")
+    mocker.patch("pathlib.Path.replace")
+    mocker.patch("pathlib.Path.stat", return_value=mocker.MagicMock(st_size=100))
+    mocker.patch("pathlib.Path.exists", return_value=False)
 
     # Simulate command-line arguments
     # Imports are placed inside the test function to ensure that the `app` object
@@ -39,7 +42,8 @@ def test_cli_options_recognized(mocker, tmp_path):
 
     assert result.exit_code == 0
     mock_ts2mp4.assert_called_once_with(
-        ts=mocker.ANY,
+        input_file=mocker.ANY,
+        output_file=mocker.ANY,
         crf=20,
         preset="slow",
     )

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -1,0 +1,16 @@
+import importlib.metadata
+
+from ts2mp4 import _get_ts2mp4_version
+
+
+def test_get_ts2mp4_version_success(mocker):
+    mocker.patch("importlib.metadata.version", return_value="1.2.3")
+    assert _get_ts2mp4_version() == "1.2.3"
+
+
+def test_get_ts2mp4_version_package_not_found(mocker):
+    mocker.patch(
+        "importlib.metadata.version",
+        side_effect=importlib.metadata.PackageNotFoundError,
+    )
+    assert _get_ts2mp4_version() == "Unknown"

--- a/tests/test_ts2mp4.py
+++ b/tests/test_ts2mp4.py
@@ -1,3 +1,4 @@
+import subprocess
 from pathlib import Path
 from unittest.mock import MagicMock
 
@@ -6,47 +7,33 @@ import pytest
 from ts2mp4.ts2mp4 import ts2mp4
 
 
-@pytest.fixture
-def mock_dependencies(mocker):
-    mock_subprocess_run = mocker.patch(
-        "ts2mp4.ts2mp4.subprocess.run", return_value=MagicMock(stdout="", stderr="")
-    )
-    mocker.patch("pathlib.Path.exists", return_value=False)
-    mocker.patch("pathlib.Path.resolve", return_value=Path("test.ts"))
-    mocker.patch(
-        "pathlib.Path.with_suffix", side_effect=lambda suffix: Path(f"test{suffix}")
-    )
-    mocker.patch("pathlib.Path.stat", return_value=MagicMock(st_size=100))
-    mocker.patch("pathlib.Path.replace")
-    mocker.patch("logzero.logfile")
-    mocker.patch("ts2mp4.ts2mp4.verify_audio_stream_integrity")
-    return mock_subprocess_run
+def test_ts2mp4_successful_conversion(mocker):
+    # Arrange
+    input_file = Path("input.ts")
+    output_file = Path("output.mp4")
+    crf = 23
+    preset = "medium"
 
-
-@pytest.mark.parametrize(
-    "crf_value, preset_value",
-    [
-        (20, "slow"),
-        (25, "fast"),
-    ],
-)
-def test_ts2mp4_custom_crf_preset(mock_dependencies, crf_value, preset_value):
-    """Test ts2mp4 with custom crf and preset values."""
-    ts_path = Path("test.ts")
-    ts2mp4(
-        input_file=ts_path,
-        output_file=ts_path.with_suffix(".mp4.part"),
-        crf=crf_value,
-        preset=preset_value,
+    mock_subprocess_run = mocker.patch("subprocess.run")
+    mock_verify_audio_stream_integrity = mocker.patch(
+        "ts2mp4.ts2mp4.verify_audio_stream_integrity"
     )
-    subprocess_run_mock = mock_dependencies
+
+    mock_subprocess_run.return_value = MagicMock(
+        stdout="ffmpeg stdout", stderr="ffmpeg stderr"
+    )
+
+    # Act
+    ts2mp4(input_file, output_file, crf, preset)
+
+    # Assert
     expected_command = [
         "ffmpeg",
         "-fflags",
         "+discardcorrupt",
         "-y",
         "-i",
-        str(ts_path.resolve()),
+        str(input_file),
         "-f",
         "mp4",
         "-vsync",
@@ -56,15 +43,41 @@ def test_ts2mp4_custom_crf_preset(mock_dependencies, crf_value, preset_value):
         "-codec:v",
         "libx265",
         "-crf",
-        str(crf_value),
+        str(crf),
         "-preset",
-        preset_value,
+        preset,
         "-codec:a",
         "copy",
         "-bsf:a",
         "aac_adtstoasc",
-        str(ts_path.with_suffix(".mp4.part")),
+        str(output_file),
     ]
-    subprocess_run_mock.assert_any_call(
+    mock_subprocess_run.assert_called_once_with(
         args=expected_command, check=True, capture_output=True, text=True
     )
+    mock_verify_audio_stream_integrity.assert_called_once_with(
+        input_file=input_file, output_file=output_file
+    )
+
+
+def test_ts2mp4_ffmpeg_failure(mocker):
+    # Arrange
+    input_file = Path("input.ts")
+    output_file = Path("output.mp4")
+    crf = 23
+    preset = "medium"
+
+    mock_subprocess_run = mocker.patch("subprocess.run")
+    mock_verify_audio_stream_integrity = mocker.patch(
+        "ts2mp4.ts2mp4.verify_audio_stream_integrity"
+    )
+
+    mock_subprocess_run.side_effect = subprocess.CalledProcessError(
+        returncode=1, cmd="ffmpeg", stderr="ffmpeg error"
+    )
+
+    # Act & Assert
+    with pytest.raises(subprocess.CalledProcessError):
+        ts2mp4(input_file, output_file, crf, preset)
+
+    mock_verify_audio_stream_integrity.assert_not_called()

--- a/tests/test_ts2mp4.py
+++ b/tests/test_ts2mp4.py
@@ -47,7 +47,12 @@ def mock_dependencies(mocker):
 def test_ts2mp4_custom_crf_preset(mock_dependencies, crf_value, preset_value):
     """Test ts2mp4 with custom crf and preset values."""
     ts_path = Path("test.ts")
-    ts2mp4(ts_path, crf=crf_value, preset=preset_value)
+    ts2mp4(
+        input_file=ts_path,
+        output_file=ts_path.with_suffix(".mp4.part"),
+        crf=crf_value,
+        preset=preset_value,
+    )
     subprocess_run_mock = mock_dependencies
     expected_command = [
         "ffmpeg",

--- a/tests/test_ts2mp4.py
+++ b/tests/test_ts2mp4.py
@@ -1,23 +1,9 @@
-import importlib.metadata
 from pathlib import Path
 from unittest.mock import MagicMock
 
 import pytest
 
-from ts2mp4.ts2mp4 import _get_ts2mp4_version, ts2mp4
-
-
-def test_get_ts2mp4_version_success(mocker):
-    mocker.patch("importlib.metadata.version", return_value="1.2.3")
-    assert _get_ts2mp4_version() == "1.2.3"
-
-
-def test_get_ts2mp4_version_package_not_found(mocker):
-    mocker.patch(
-        "importlib.metadata.version",
-        side_effect=importlib.metadata.PackageNotFoundError,
-    )
-    assert _get_ts2mp4_version() == "Unknown"
+from ts2mp4.ts2mp4 import ts2mp4
 
 
 @pytest.fixture

--- a/ts2mp4/__init__.py
+++ b/ts2mp4/__init__.py
@@ -1,0 +1,8 @@
+import importlib.metadata
+
+
+def _get_ts2mp4_version() -> str:
+    try:
+        return importlib.metadata.version("ts2mp4")
+    except importlib.metadata.PackageNotFoundError:
+        return "Unknown"

--- a/ts2mp4/cli.py
+++ b/ts2mp4/cli.py
@@ -8,7 +8,8 @@ import logzero
 import typer
 from logzero import logger
 
-from ts2mp4.ts2mp4 import _get_ts2mp4_version, ts2mp4
+from ts2mp4 import _get_ts2mp4_version
+from ts2mp4.ts2mp4 import ts2mp4
 
 
 class Preset(str, Enum):

--- a/ts2mp4/cli.py
+++ b/ts2mp4/cli.py
@@ -1,3 +1,5 @@
+import datetime
+import platform
 from enum import Enum
 from pathlib import Path
 from typing import Annotated, Union
@@ -6,7 +8,7 @@ import logzero
 import typer
 from logzero import logger
 
-from ts2mp4.ts2mp4 import ts2mp4
+from ts2mp4.ts2mp4 import _get_ts2mp4_version, ts2mp4
 
 
 class Preset(str, Enum):
@@ -51,7 +53,20 @@ def main(
     logzero.logfile(str(log_file))
 
     try:
+        start_time = datetime.datetime.now()
+        logger.info(f"Conversion Log for {path.name}")
+        logger.info(f"Start Time: {start_time}")
+        logger.info(f"Input File: {path.resolve()}")
+        logger.info(f"Input File Size: {path.stat().st_size} bytes")
+
         ts2mp4(ts=path, crf=crf, preset=preset)
+
+        end_time = datetime.datetime.now()
+        logger.info(f"End Time: {end_time}")
+        logger.info(f"Duration: {end_time - start_time}")
+        logger.info(f"ts2mp4 Version: {_get_ts2mp4_version()}")
+        logger.info(f"Python Version: {platform.python_version()}")
+        logger.info(f"Platform: {platform.platform()}")
     except Exception:
         logger.exception("An error occurred during conversion.")
         raise typer.Exit(code=1)

--- a/ts2mp4/cli.py
+++ b/ts2mp4/cli.py
@@ -59,7 +59,21 @@ def main(
         logger.info(f"Input File: {path.resolve()}")
         logger.info(f"Input File Size: {path.stat().st_size} bytes")
 
-        ts2mp4(ts=path, crf=crf, preset=preset)
+        ts_resolved = path.resolve()
+        mp4 = ts_resolved.with_suffix(".mp4")
+        mp4_part = ts_resolved.with_suffix(".mp4.part")
+
+        if mp4.exists():
+            logger.info(f"Output file {mp4.name} already exists. Skipping conversion.")
+            return
+
+        ts2mp4(input_file=ts_resolved, output_file=mp4_part, crf=crf, preset=preset)
+
+        logger.info("Conversion Status: Success")
+
+        mp4_part.replace(mp4)
+        logger.info(f"Output File: {mp4.resolve()}")
+        logger.info(f"Output File Size: {mp4.stat().st_size} bytes")
 
         end_time = datetime.datetime.now()
         logger.info(f"End Time: {end_time}")

--- a/ts2mp4/ts2mp4.py
+++ b/ts2mp4/ts2mp4.py
@@ -7,6 +7,20 @@ from .audio_integrity import verify_audio_stream_integrity
 
 
 def ts2mp4(input_file: Path, output_file: Path, crf: int, preset: str):
+    """Converts a Transport Stream (TS) file to MP4 format using FFmpeg.
+
+    This function constructs and executes an FFmpeg command to perform the video
+    conversion. It also logs the FFmpeg output and verifies the audio stream
+    integrity of the converted file.
+
+    Args:
+        input_file: The path to the input TS file.
+        output_file: The path where the output MP4 file will be saved.
+        crf: The Constant Rate Factor (CRF) value for video encoding. Lower
+            values result in higher quality and larger file sizes.
+        preset: The encoding preset for FFmpeg. This affects the compression
+            speed and efficiency (e.g., 'medium', 'fast', 'slow').
+    """
     ffmpeg_command = [
         "ffmpeg",
         "-fflags",

--- a/ts2mp4/ts2mp4.py
+++ b/ts2mp4/ts2mp4.py
@@ -14,22 +14,14 @@ def _get_ts2mp4_version() -> str:
         return "Unknown"
 
 
-def ts2mp4(ts: Path, crf: int, preset: str):
-    ts = ts.resolve()
-    mp4 = ts.with_suffix(".mp4")
-    mp4_part = ts.with_suffix(".mp4.part")
-
-    if mp4.exists():
-        logger.info(f"Output file {mp4.name} already exists. Skipping conversion.")
-        return
-
+def ts2mp4(input_file: Path, output_file: Path, crf: int, preset: str):
     ffmpeg_command = [
         "ffmpeg",
         "-fflags",
         "+discardcorrupt",
         "-y",
         "-i",
-        str(ts),
+        str(input_file),
         "-f",
         "mp4",
         "-vsync",
@@ -46,7 +38,7 @@ def ts2mp4(ts: Path, crf: int, preset: str):
         "copy",
         "-bsf:a",
         "aac_adtstoasc",
-        str(mp4_part),
+        str(output_file),
     ]
     logger.info(f"FFmpeg Command: {' '.join(ffmpeg_command)}")
 
@@ -56,12 +48,7 @@ def ts2mp4(ts: Path, crf: int, preset: str):
         capture_output=True,
         text=True,
     )
-    logger.info("Conversion Status: Success")
     logger.info("FFmpeg Stdout:\n" + process.stdout)
     logger.info("FFmpeg Stderr:\n" + process.stderr)
 
-    verify_audio_stream_integrity(ts, mp4_part)
-
-    mp4_part.replace(mp4)
-    logger.info(f"Output File: {mp4.resolve()}")
-    logger.info(f"Output File Size: {mp4.stat().st_size} bytes")
+    verify_audio_stream_integrity(input_file=input_file, output_file=output_file)

--- a/ts2mp4/ts2mp4.py
+++ b/ts2mp4/ts2mp4.py
@@ -1,17 +1,9 @@
-import importlib.metadata
 import subprocess
 from pathlib import Path
 
 from logzero import logger
 
 from .audio_integrity import verify_audio_stream_integrity
-
-
-def _get_ts2mp4_version() -> str:
-    try:
-        return importlib.metadata.version("ts2mp4")
-    except importlib.metadata.PackageNotFoundError:
-        return "Unknown"
 
 
 def ts2mp4(input_file: Path, output_file: Path, crf: int, preset: str):

--- a/ts2mp4/ts2mp4.py
+++ b/ts2mp4/ts2mp4.py
@@ -1,6 +1,4 @@
-import datetime
 import importlib.metadata
-import platform
 import subprocess
 from pathlib import Path
 
@@ -17,12 +15,6 @@ def _get_ts2mp4_version() -> str:
 
 
 def ts2mp4(ts: Path, crf: int, preset: str):
-    start_time = datetime.datetime.now()
-    logger.info(f"Conversion Log for {ts.name}")
-    logger.info(f"Start Time: {start_time}")
-    logger.info(f"Input File: {ts.resolve()}")
-    logger.info(f"Input File Size: {ts.stat().st_size} bytes")
-
     ts = ts.resolve()
     mp4 = ts.with_suffix(".mp4")
     mp4_part = ts.with_suffix(".mp4.part")
@@ -73,10 +65,3 @@ def ts2mp4(ts: Path, crf: int, preset: str):
     mp4_part.replace(mp4)
     logger.info(f"Output File: {mp4.resolve()}")
     logger.info(f"Output File Size: {mp4.stat().st_size} bytes")
-
-    end_time = datetime.datetime.now()
-    logger.info(f"End Time: {end_time}")
-    logger.info(f"Duration: {end_time - start_time}")
-    logger.info(f"ts2mp4 Version: {_get_ts2mp4_version()}")
-    logger.info(f"Python Version: {platform.python_version()}")
-    logger.info(f"Platform: {platform.platform()}")


### PR DESCRIPTION
- **Refactor: Move conversion logging to CLI**
- **Refactor: Update ts2mp4 function signature and move file handling**
- **Refactor: Move `_get_ts2mp4_version` to `__init__.py` and its tests to `test_init.py`**
- **Docs: Add docstring to `ts2mp4` function**
- **refactor(tests): Restructure ts2mp4 tests and update mocking approach**
