### PR TITLE
refactor: Integrate test asset generation into 'make check'

### DIFF
--- a/.github/workflows/ci-release.yml
+++ b/.github/workflows/ci-release.yml
@@ -32,9 +32,6 @@ jobs:
       - name: Install ffmpeg
         run: sudo apt-get update && sudo apt-get install -y ffmpeg
 
-      - name: Generate test assets
-        run: make tests/assets/test_video.ts
-
       - name: Run all checks
         run: make check
 

--- a/Makefile
+++ b/Makefile
@@ -1,12 +1,12 @@
+TEST_ASSETS_DIR = tests/assets
+
 .PHONY: check
-check:
+check: $(TEST_ASSETS_DIR)/test_video.ts
 	poetry run black --check .
 	poetry run isort --check .
 	poetry run flake8 .
 	poetry run mypy .
 	poetry run pytest
-
-TEST_ASSETS_DIR = tests/assets
 
 $(TEST_ASSETS_DIR)/test_video.ts: Makefile
 	@mkdir -p $(TEST_ASSETS_DIR)


### PR DESCRIPTION
- Remove explicit test asset generation from CI workflow.
- Add test asset generation as a prerequisite for the 'check' target in Makefile.
- This streamlines the build process by ensuring test assets are generated automatically when running 'make check'.
