### PR TITLE
feat: Separate e2e tests in Makefile check target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,8 @@ check: $(TEST_ASSETS_DIR)/test_video.ts
 	poetry run isort --check .
 	poetry run flake8 .
 	poetry run mypy .
-	poetry run pytest
+	poetry run pytest --ignore=tests/test_e2e.py
+	poetry run pytest tests/test_e2e.py
 
 $(TEST_ASSETS_DIR)/test_video.ts: Makefile
 	@mkdir -p $(TEST_ASSETS_DIR)


### PR DESCRIPTION
E2E tests are now run only after all other tests have passed in the `make check` command. This ensures faster feedback for non-e2e changes and only runs the time-consuming e2e tests when necessary.
