### PR TITLE
feat: Add -nostats option to ffmpeg command

### DIFF
--- a/tests/test_ts2mp4.py
+++ b/tests/test_ts2mp4.py
@@ -29,6 +29,7 @@ def test_ts2mp4_successful_conversion(mocker):
     # Assert
     expected_command = [
         "ffmpeg",
+        "-nostats",
         "-fflags",
         "+discardcorrupt",
         "-y",

--- a/ts2mp4/ts2mp4.py
+++ b/ts2mp4/ts2mp4.py
@@ -23,6 +23,7 @@ def ts2mp4(input_file: Path, output_file: Path, crf: int, preset: str):
     """
     ffmpeg_command = [
         "ffmpeg",
+        "-nostats",
         "-fflags",
         "+discardcorrupt",
         "-y",


### PR DESCRIPTION
- Add the `-nostats` option to the ffmpeg command to suppress progress logs.
- Update tests to reflect the change in the ffmpeg command.