### PR TITLE
feat: Configure mypy to run in strict mode

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,8 +2,12 @@
 profile = "black"
 
 [tool.mypy]
-ignore_missing_imports = true
+strict = true
 exclude = [".venv", "build", "dist"]
+
+[[tool.mypy.overrides]]
+module = "logzero"
+ignore_missing_imports = true
 
 [tool.poetry]
 name = "ts2mp4"

--- a/tests/test_audio_integrity.py
+++ b/tests/test_audio_integrity.py
@@ -1,6 +1,7 @@
 from pathlib import Path
 
 import pytest
+from pytest_mock import MockerFixture
 
 from ts2mp4.audio_integrity import (
     _get_audio_stream_count,
@@ -9,21 +10,21 @@ from ts2mp4.audio_integrity import (
 )
 
 
-def test_get_audio_stream_count(ts_file: Path):
+def test_get_audio_stream_count(ts_file: Path) -> None:
     """Test the _get_audio_stream_count helper function."""
     expected_stream_count = 1
     actual_stream_count = _get_audio_stream_count(ts_file)
     assert actual_stream_count == expected_stream_count
 
 
-def test_get_audio_stream_md5(ts_file: Path):
+def test_get_audio_stream_md5(ts_file: Path) -> None:
     """Test the _get_audio_stream_md5 helper function."""
     expected_md5 = "9db9dd4cb46b9678894578946158955b"
     actual_md5 = _get_audio_stream_md5(ts_file, 0)
     assert actual_md5 == expected_md5
 
 
-def test_verify_audio_stream_integrity_matches(mocker):
+def test_verify_audio_stream_integrity_matches(mocker: MockerFixture) -> None:
     input_file = Path("dummy_input.ts")
     output_file = Path("dummy_output.mp4.part")
 
@@ -41,7 +42,7 @@ def test_verify_audio_stream_integrity_matches(mocker):
     verify_audio_stream_integrity(input_file, output_file)
 
 
-def test_verify_audio_stream_integrity_mismatch(mocker):
+def test_verify_audio_stream_integrity_mismatch(mocker: MockerFixture) -> None:
     input_file = Path("dummy_input.ts")
     output_file = Path("dummy_output.mp4.part")
 
@@ -60,7 +61,9 @@ def test_verify_audio_stream_integrity_mismatch(mocker):
     assert "Audio stream MD5 mismatch!" in str(excinfo.value)
 
 
-def test_verify_audio_stream_integrity_no_audio_streams(mocker):
+def test_verify_audio_stream_integrity_no_audio_streams(
+    mocker: MockerFixture,
+) -> None:
     input_file = Path("dummy_input_no_audio.ts")
     output_file = Path("dummy_output_no_audio.mp4.part")
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,6 +1,9 @@
 import subprocess
+from pathlib import Path
+from typing import List
 
 import pytest
+from pytest_mock import MockerFixture
 
 
 @pytest.mark.parametrize(
@@ -10,7 +13,7 @@ import pytest
         ["poetry", "run", "python", "-m", "ts2mp4", "--help"],
     ],
 )
-def test_cli_entry_points_start_correctly(command):
+def test_cli_entry_points_start_correctly(command: List[str]) -> None:
     """Test that CLI entry points run without error and show help message."""
     result = subprocess.run(command, capture_output=True, text=True, check=True)
 
@@ -18,7 +21,7 @@ def test_cli_entry_points_start_correctly(command):
     assert "Usage:" in result.stdout
 
 
-def test_cli_options_recognized(mocker, tmp_path):
+def test_cli_options_recognized(mocker: MockerFixture, tmp_path: Path) -> None:
     """Test that the CLI recognizes the --crf and --preset options."""
     mock_ts2mp4 = mocker.patch("ts2mp4.ts2mp4.ts2mp4")
     mocker.patch("pathlib.Path.replace")
@@ -49,7 +52,7 @@ def test_cli_options_recognized(mocker, tmp_path):
     )
 
 
-def test_cli_invalid_crf_value(tmp_path):
+def test_cli_invalid_crf_value(tmp_path: Path) -> None:
     """Test that the CLI handles invalid CRF values gracefully."""
     dummy_ts_path = tmp_path / "dummy.ts"
     dummy_ts_path.write_text("dummy")
@@ -65,7 +68,7 @@ def test_cli_invalid_crf_value(tmp_path):
     assert result.returncode != 0
 
 
-def test_cli_invalid_preset_value(mocker, tmp_path):
+def test_cli_invalid_preset_value(mocker: MockerFixture, tmp_path: Path) -> None:
     """Test that the CLI handles invalid preset values gracefully."""
     mock_ts2mp4 = mocker.patch("ts2mp4.ts2mp4.ts2mp4")
 

--- a/tests/test_e2e.py
+++ b/tests/test_e2e.py
@@ -1,11 +1,12 @@
 import subprocess
 from pathlib import Path
+from typing import Generator
 
 import pytest
 
 
 @pytest.fixture(autouse=True)
-def cleanup_mp4_file(mp4_file: Path):
+def cleanup_mp4_file(mp4_file: Path) -> Generator[None, None, None]:
     """Ensures the .mp4 file is removed before and after each test."""
     if mp4_file.exists():
         mp4_file.unlink()
@@ -14,7 +15,9 @@ def cleanup_mp4_file(mp4_file: Path):
         mp4_file.unlink()
 
 
-def test_ts2mp4_conversion_success(ts_file: Path, mp4_file: Path, project_root: Path):
+def test_ts2mp4_conversion_success(
+    ts_file: Path, mp4_file: Path, project_root: Path
+) -> None:
     """Test successful conversion of a .ts file to .mp4."""
     command = ["poetry", "run", "ts2mp4", str(ts_file)]
     subprocess.run(command, capture_output=True, cwd=project_root, check=True)
@@ -23,7 +26,7 @@ def test_ts2mp4_conversion_success(ts_file: Path, mp4_file: Path, project_root: 
     assert mp4_file.stat().st_size > 0
 
 
-def test_ts2mp4_file_not_found_error(mp4_file: Path, project_root: Path):
+def test_ts2mp4_file_not_found_error(mp4_file: Path, project_root: Path) -> None:
     """Test error handling when the input .ts file does not exist."""
     non_existent_file = project_root / "non_existent.ts"
     command = ["poetry", "run", "ts2mp4", str(non_existent_file)]
@@ -32,7 +35,7 @@ def test_ts2mp4_file_not_found_error(mp4_file: Path, project_root: Path):
     assert not mp4_file.exists()
 
 
-def test_ts2mp4_no_input_file_error(mp4_file: Path, project_root: Path):
+def test_ts2mp4_no_input_file_error(mp4_file: Path, project_root: Path) -> None:
     """Test error handling when no input file is provided."""
     command = ["poetry", "run", "ts2mp4"]
     with pytest.raises(subprocess.CalledProcessError):

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -1,14 +1,16 @@
 import importlib.metadata
 
+from pytest_mock import MockerFixture
+
 from ts2mp4 import _get_ts2mp4_version
 
 
-def test_get_ts2mp4_version_success(mocker):
+def test_get_ts2mp4_version_success(mocker: MockerFixture) -> None:
     mocker.patch("importlib.metadata.version", return_value="1.2.3")
     assert _get_ts2mp4_version() == "1.2.3"
 
 
-def test_get_ts2mp4_version_package_not_found(mocker):
+def test_get_ts2mp4_version_package_not_found(mocker: MockerFixture) -> None:
     mocker.patch(
         "importlib.metadata.version",
         side_effect=importlib.metadata.PackageNotFoundError,

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -2,7 +2,7 @@ import subprocess
 from pathlib import Path
 
 
-def test_log_file_creation_and_content(tmp_path: Path, project_root: Path):
+def test_log_file_creation_and_content(tmp_path: Path, project_root: Path) -> None:
     """Test that a log file is created and contains expected messages."""
 
     # Define paths directly using tmp_path

--- a/tests/test_ts2mp4.py
+++ b/tests/test_ts2mp4.py
@@ -3,11 +3,12 @@ from pathlib import Path
 from unittest.mock import MagicMock
 
 import pytest
+from pytest_mock import MockerFixture
 
 from ts2mp4.ts2mp4 import ts2mp4
 
 
-def test_ts2mp4_successful_conversion(mocker):
+def test_ts2mp4_successful_conversion(mocker: MockerFixture) -> None:
     # Arrange
     input_file = Path("input.ts")
     output_file = Path("output.mp4")
@@ -66,7 +67,7 @@ def test_ts2mp4_successful_conversion(mocker):
     )
 
 
-def test_ts2mp4_handles_non_utf8_ffmpeg_output(mocker):
+def test_ts2mp4_handles_non_utf8_ffmpeg_output(mocker: MockerFixture) -> None:
     # Arrange
     input_file = Path("input.ts")
     output_file = Path("output.mp4")
@@ -89,7 +90,7 @@ def test_ts2mp4_handles_non_utf8_ffmpeg_output(mocker):
         pytest.fail("ts2mp4 should not raise UnicodeDecodeError")
 
 
-def test_ts2mp4_ffmpeg_failure(mocker):
+def test_ts2mp4_ffmpeg_failure(mocker: MockerFixture) -> None:
     # Arrange
     input_file = Path("input.ts")
     output_file = Path("output.mp4")

--- a/ts2mp4/audio_integrity.py
+++ b/ts2mp4/audio_integrity.py
@@ -85,7 +85,7 @@ def _get_audio_stream_md5(file_path: Path, stream_index: int) -> str:
     return hashlib.md5(result.stdout).hexdigest()
 
 
-def verify_audio_stream_integrity(input_file: Path, output_file: Path):
+def verify_audio_stream_integrity(input_file: Path, output_file: Path) -> None:
     """Verifies the integrity of audio streams by comparing MD5 hashes before and after conversion.
 
     Args:

--- a/ts2mp4/cli.py
+++ b/ts2mp4/cli.py
@@ -48,7 +48,7 @@ def main(
     preset: Annotated[
         Preset, typer.Option(help="Encoding preset. Defaults to 'slow'.")
     ] = Preset.slow,
-):
+) -> None:
     if log_file is None:
         log_file = path.with_suffix(".log")
     logzero.logfile(str(log_file))

--- a/ts2mp4/ts2mp4.py
+++ b/ts2mp4/ts2mp4.py
@@ -6,7 +6,7 @@ from logzero import logger
 from .audio_integrity import verify_audio_stream_integrity
 
 
-def ts2mp4(input_file: Path, output_file: Path, crf: int, preset: str):
+def ts2mp4(input_file: Path, output_file: Path, crf: int, preset: str) -> None:
     """Converts a Transport Stream (TS) file to MP4 format using FFmpeg.
 
     This function constructs and executes an FFmpeg command to perform the video


### PR DESCRIPTION
Updated `pyproject.toml` to run mypy in strict mode and fixed the resulting type annotation errors.

- Changed mypy setting to `strict = true` in `pyproject.toml`
- Excluded `logzero` module from mypy checks
- Added type annotations to functions in each file