### PR TITLE
feat: Add -hide_banner to ffmpeg and ffprobe commands

### DIFF
--- a/tests/test_ts2mp4.py
+++ b/tests/test_ts2mp4.py
@@ -28,6 +28,7 @@ def test_calls_ffmpeg_with_correct_args(mocker: MockerFixture) -> None:
     # Assert
     expected_command = [
         "ffmpeg",
+        "-hide_banner",
         "-nostats",
         "-fflags",
         "+discardcorrupt",

--- a/ts2mp4/audio_integrity.py
+++ b/ts2mp4/audio_integrity.py
@@ -20,6 +20,7 @@ def _get_audio_stream_count(file_path: Path) -> int:
     """
     command = [
         "ffprobe",
+        "-hide_banner",
         "-v",
         "error",
         "-show_entries",
@@ -61,6 +62,7 @@ def _get_audio_stream_md5(file_path: Path, stream_index: int) -> str:
     """
     command = [
         "ffmpeg",
+        "-hide_banner",
         "-i",
         str(file_path),
         "-map",

--- a/ts2mp4/ts2mp4.py
+++ b/ts2mp4/ts2mp4.py
@@ -23,6 +23,7 @@ def ts2mp4(input_file: Path, output_file: Path, crf: int, preset: str) -> None:
     """
     ffmpeg_command = [
         "ffmpeg",
+        "-hide_banner",
         "-nostats",
         "-fflags",
         "+discardcorrupt",


### PR DESCRIPTION
This change adds the -hide_banner flag to all ffmpeg and ffprobe commands to suppress the printing of the banner, version information, and copyright notices.