### PR TITLE
docs: Refactor AGENTS.md for clarity and improved structure

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,32 +6,61 @@ For general project information, including project overview, technology stack, p
 
 ## 1. Coding Guidelines
 
+### 1.1. Code Style
+
 *   Follow the style of the existing codebase (indentation, naming conventions, etc.).
+
+### 1.2. Comments
+
 *   Write comments in English.
+
+### 1.3. File Endings
+
 *   Ensure all files end with a single newline character.
+
+### 1.4. Verification
+
+*   Always run existing tests before making changes to ensure no regressions.
+
+### 1.5. Makefile Usage
+
+*   Prioritize using commands defined in the `Makefile` if available.
 
 ## 2. Git Guidelines
 
-*   **Branch Naming**:
-    *   When creating new branches for features, bug fixes, or other tasks, use descriptive prefixes such as `feature/`, `bugfix/`, or `hotfix/` (e.g., `feature/add-new-cli-command`).
-*   **Commit Message Creation**:
-    *   **Diff-based Content**:
-        *   Focus solely on the changes being committed. Disregard the agent's conversation history.
-        *   Ensure every point in the proposed commit message directly corresponds to a visible change in the *diff of the changes being committed*. This typically means `git diff --staged` for staged changes, or `git diff HEAD` for unstaged changes if committing with `-a`. Do not include information not explicitly present in that diff.
-    *   **Formatting**:
-        *   When using `git commit -m`, always enclose the entire commit message in single quotes to prevent shell interpretation of inline code blocks or special characters.
-*   **Commit Failures**: If a commit operation fails, especially due to issues with multi-line strings or special characters in the commit message (even when enclosed in single quotes), try the following workaround:
+### 2.1. Branch Naming
+
+*   When creating new branches for features, bug fixes, or other tasks, use descriptive prefixes such as `feature/`, `bugfix/`, or `hotfix/` (e.g., `feature/add-new-cli-command`).
+
+### 2.2. Commit Message Creation
+
+#### 2.2.1. Diff-based Content
+
+*   Focus solely on the changes being committed. Disregard the agent's conversation history.
+*   Ensure every point in the proposed commit message directly corresponds to a visible change in the *diff of the changes being committed*. This typically means `git diff --staged` for staged changes, or `git diff HEAD` for unstaged changes if committing with `-a`. Do not include information not explicitly present in that diff.
+
+#### 2.2.2. Formatting
+
+*   When using `git commit -m`, always enclose the entire commit message in single quotes to prevent shell interpretation of inline code blocks or special characters.
+
+### 2.3. Commit Failures
+
+*   If a commit operation fails, especially due to issues with multi-line strings or special characters in the commit message (even when enclosed in single quotes), try the following workaround:
     1.  Write the desired commit message to `.git/COMMIT_EDITMSG`.
     2.  Execute `git commit -F .git/COMMIT_EDITMSG` to apply the commit message from the file.
-    3.  If the issue is still different, inform the user about the failure and await guidance.
+    3.  If the original issue persists or a new one emerges, inform the user about the failure and await guidance.
 
 ## 3. Interaction
 
-*   **Interaction Language**: The agent will adapt its communication language to match the language used by the user in the current conversation.
+### 3.1. Interaction Language
+
+*   The agent will adapt its communication language to match the language used by the user in the current conversation.
 
 ## 4. Debugging Principles
 
-*   **Test Failure Debugging Principle**: When a test fails, **prioritize factual problem isolation over speculative cause analysis**. Do not attempt to fix based on assumptions. Instead, systematically gather concrete evidence from the failing environment to pinpoint the exact point of failure and its direct cause. This involves:
+### 4.1. Test Failure Debugging Principle
+
+*   When a test fails, **prioritize factual problem isolation over speculative cause analysis**. Do not attempt to fix based on assumptions. Instead, systematically gather concrete evidence from the failing environment to pinpoint the exact point of failure and its direct cause. This involves:
     1.  **Literal Interpretation of Error Messages**: Understand what the error message *literally* states, without adding unverified interpretations.
     2.  **Verification of Assumptions**: If an assumption is made (e.g., "file exists"), programmatically verify it within the context where the failure occurs (e.g., inside a subprocess).
     3.  **Systematic Isolation**: Use debugging techniques (e.g., temporary logging, conditional breakpoints) to narrow down the problem to the smallest possible scope.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,31 +2,36 @@
 
 This file provides guidelines and context for AI agents (like me) working on the `ts2mp4` project.
 
-## 1. Coding Standards
+For general project information, including project overview, technology stack, project structure, and development workflow, please refer to `README.md`.
 
-*   Adhere to PEP 8.
+## 1. Coding Guidelines
+
 *   Follow the style of the existing codebase (indentation, naming conventions, etc.).
-*   Actively use type hints.
 *   Write comments in English.
 *   Ensure all files end with a single newline character.
 
-## 2. Git Workflow
+## 2. Git Guidelines
 
-*   When creating new branches for features, bug fixes, or other tasks, use descriptive prefixes such as `feature/`, `bugfix/`, or `hotfix/` (e.g., `feature/add-new-cli-command`).
-
-## 3. Important Considerations for AI Agents
-
-*   **Common Tasks**: AI agents are expected to perform tasks such as bug fixes, implementing new features, refactoring existing code, adding/updating tests, and updating documentation.
-*   **Verification**: Always run existing tests before making changes to ensure no regressions.
-*   **Dependencies**: If adding new dependencies, ensure `pyproject.toml` and `poetry.lock` are updated.
-*   **Makefile Usage**: Prioritize using commands defined in the `Makefile` if available.
-*   **Interaction Language**: The agent will adapt its communication language to match the language used by the user in the current conversation.
-*   **Commit Failures**: If a commit operation fails, especially due to issues with multi-line strings in the commit message, try the following workaround:
+*   **Branch Naming**:
+    *   When creating new branches for features, bug fixes, or other tasks, use descriptive prefixes such as `feature/`, `bugfix/`, or `hotfix/` (e.g., `feature/add-new-cli-command`).
+*   **Commit Message Creation**:
+    *   **Diff-based Content**:
+        *   Focus solely on the changes being committed. Disregard the agent's conversation history.
+        *   Ensure every point in the proposed commit message directly corresponds to a visible change in the *diff of the changes being committed*. This typically means `git diff --staged` for staged changes, or `git diff HEAD` for unstaged changes if committing with `-a`. Do not include information not explicitly present in that diff.
+    *   **Formatting**:
+        *   When using `git commit -m`, always enclose the entire commit message in single quotes to prevent shell interpretation of inline code blocks or special characters.
+*   **Commit Failures**: If a commit operation fails, especially due to issues with multi-line strings or special characters in the commit message (even when enclosed in single quotes), try the following workaround:
     1.  Write the desired commit message to `.git/COMMIT_EDITMSG`.
     2.  Execute `git commit -F .git/COMMIT_EDITMSG` to apply the commit message from the file.
-    3.  If the issue persists or is different, inform the user about the failure and await guidance.
-*   **Commit Message Creation**: When crafting commit messages, focus solely on the staged diff. Disregard the agent's conversation history, as the commit message should accurately reflect the changes introduced by the commit itself. **Always run `git diff --staged` before proposing a commit message to ensure it accurately reflects only the staged changes.** When using `git commit -m`, always enclose the entire commit message in single quotes to prevent shell interpretation of inline code blocks or special characters.
-*   **Test Failure Debugging Principle**: When a test fails, **prioritize factual problem isolation over speculative cause analysis**. Do not attempt to fix based on assumptions. Instead, systematically gather concrete evidence from the failing environment to pinpoint the exact point of failure and its direct cause. This involves: 
+    3.  If the issue is still different, inform the user about the failure and await guidance.
+
+## 3. Interaction
+
+*   **Interaction Language**: The agent will adapt its communication language to match the language used by the user in the current conversation.
+
+## 4. Debugging Principles
+
+*   **Test Failure Debugging Principle**: When a test fails, **prioritize factual problem isolation over speculative cause analysis**. Do not attempt to fix based on assumptions. Instead, systematically gather concrete evidence from the failing environment to pinpoint the exact point of failure and its direct cause. This involves:
     1.  **Literal Interpretation of Error Messages**: Understand what the error message *literally* states, without adding unverified interpretations.
     2.  **Verification of Assumptions**: If an assumption is made (e.g., "file exists"), programmatically verify it within the context where the failure occurs (e.g., inside a subprocess).
     3.  **Systematic Isolation**: Use debugging techniques (e.g., temporary logging, conditional breakpoints) to narrow down the problem to the smallest possible scope.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,7 +12,7 @@ For general project information, including project overview, technology stack, p
 
 ### 1.2. Comments
 
-*   Write comments in English.
+*   Write comments in English. This rule applies regardless of the user's interaction language.
 
 ### 1.3. File Endings
 
@@ -42,6 +42,10 @@ For general project information, including project overview, technology stack, p
 #### 2.2.2. Formatting
 
 *   When using `git commit -m`, always enclose the entire commit message in single quotes to prevent shell interpretation of inline code blocks or special characters.
+
+#### 2.2.3. Language
+
+*   Commit messages must be written in English. This rule applies regardless of the user's interaction language.
 
 ### 2.3. Commit Failures
 


### PR DESCRIPTION
- Direct users to README.md for general project information.
- Rename sections to "Coding Guidelines", "Git Guidelines", "Interaction", and "Debugging Principles" for better clarity and logical grouping.
- Refine coding guidelines to focus on aspects not covered by linters or README.
- Reorder and detail Git-related guidelines, including commit message creation and failure handling, with consistent formatting.
