### PR TITLE
Refactor: Introduce command module for subprocess execution

### DIFF
--- a/tests/test_command.py
+++ b/tests/test_command.py
@@ -1,0 +1,83 @@
+import io
+import logging
+import subprocess
+import sys
+
+import logzero
+import pytest
+
+from ts2mp4.command import execute_command
+
+
+def test_execute_command_success() -> None:
+    """Test that execute_command runs a command successfully."""
+    result = execute_command(["echo", "hello"])
+    assert result.stdout.strip() == "hello"
+    assert result.stderr == ""
+    assert result.returncode == 0
+
+
+def test_execute_command_failure() -> None:
+    """Test that execute_command raises CalledProcessError on failure."""
+    with pytest.raises(subprocess.CalledProcessError) as e:
+        execute_command(["false"])
+    assert e.value.returncode == 1
+
+
+def test_handles_non_utf8_output() -> None:
+    """Test that execute_command handles non-UTF-8 output correctly."""
+    # This command prints a non-UTF-8 byte to stderr.
+    command = [
+        sys.executable,
+        "-c",
+        "import sys; sys.stderr.buffer.write(b'\\xff'); sys.exit(1)",
+    ]
+    log_stream = io.StringIO()
+    handler = logging.StreamHandler(log_stream)
+    logzero.logger.addHandler(handler)
+
+    with pytest.raises(subprocess.CalledProcessError):
+        execute_command(command)
+
+    logzero.logger.removeHandler(handler)
+    log_contents = log_stream.getvalue()
+    assert "�" in log_contents
+
+
+def test_logs_on_success() -> None:
+    """Test that execute_command logs stdout and stderr on success."""
+    command = [
+        sys.executable,
+        "-c",
+        "import sys; sys.stdout.write('success stdout'); sys.stderr.write('success stderr')",
+    ]
+    log_stream = io.StringIO()
+    handler = logging.StreamHandler(log_stream)
+    logzero.logger.addHandler(handler)
+
+    execute_command(command)
+
+    logzero.logger.removeHandler(handler)
+    log_contents = log_stream.getvalue()
+    assert "success stdout" in log_contents
+    assert "success stderr" in log_contents
+
+
+def test_logs_on_failure() -> None:
+    """Test that execute_command logs stdout and stderr on failure."""
+    command = [
+        sys.executable,
+        "-c",
+        "import sys; sys.stdout.write('some stdout'); sys.stderr.write('some stderr'); sys.exit(1)",
+    ]
+    log_stream = io.StringIO()
+    handler = logging.StreamHandler(log_stream)
+    logzero.logger.addHandler(handler)
+
+    with pytest.raises(subprocess.CalledProcessError):
+        execute_command(command)
+
+    logzero.logger.removeHandler(handler)
+    log_contents = log_stream.getvalue()
+    assert "some stdout" in log_contents
+    assert "some stderr" in log_contents

--- a/tests/test_ts2mp4.py
+++ b/tests/test_ts2mp4.py
@@ -1,6 +1,5 @@
 import subprocess
 from pathlib import Path
-from unittest.mock import MagicMock
 
 import pytest
 from pytest_mock import MockerFixture
@@ -8,19 +7,15 @@ from pytest_mock import MockerFixture
 from ts2mp4.ts2mp4 import ts2mp4
 
 
-def test_calls_ffmpeg_with_correct_args(mocker: MockerFixture) -> None:
+def test_calls_execute_command_with_correct_args(mocker: MockerFixture) -> None:
     # Arrange
     input_file = Path("input.ts")
     output_file = Path("output.mp4")
     crf = 23
     preset = "medium"
 
-    mock_subprocess_run = mocker.patch("subprocess.run")
+    mock_execute_command = mocker.patch("ts2mp4.ts2mp4.execute_command")
     mocker.patch("ts2mp4.ts2mp4.verify_audio_stream_integrity")
-
-    mock_subprocess_run.return_value = MagicMock(
-        stdout="ffmpeg stdout", stderr="ffmpeg stderr"
-    )
 
     # Act
     ts2mp4(input_file, output_file, crf, preset)
@@ -61,14 +56,7 @@ def test_calls_ffmpeg_with_correct_args(mocker: MockerFixture) -> None:
         "aac_adtstoasc",
         str(output_file),
     ]
-    mock_subprocess_run.assert_called_once_with(
-        args=expected_command,
-        check=True,
-        capture_output=True,
-        text=True,
-        encoding="utf-8",
-        errors="replace",
-    )
+    mock_execute_command.assert_called_once_with(expected_command)
 
 
 def test_calls_verify_audio_stream_integrity_on_success(mocker: MockerFixture) -> None:
@@ -78,7 +66,7 @@ def test_calls_verify_audio_stream_integrity_on_success(mocker: MockerFixture) -
     crf = 23
     preset = "medium"
 
-    mocker.patch("subprocess.run")
+    mocker.patch("ts2mp4.ts2mp4.execute_command")
     mock_verify_audio_stream_integrity = mocker.patch(
         "ts2mp4.ts2mp4.verify_audio_stream_integrity"
     )
@@ -92,30 +80,7 @@ def test_calls_verify_audio_stream_integrity_on_success(mocker: MockerFixture) -
     )
 
 
-def test_handles_non_utf8_ffmpeg_output(mocker: MockerFixture) -> None:
-    # Arrange
-    input_file = Path("input.ts")
-    output_file = Path("output.mp4")
-    crf = 23
-    preset = "medium"
-
-    mock_subprocess_run = mocker.patch("subprocess.run")
-    mocker.patch("ts2mp4.ts2mp4.verify_audio_stream_integrity")
-
-    # Simulate ffmpeg output with invalid UTF-8 bytes
-    non_utf8_stderr = b"ffmpeg stderr with invalid byte: \xc6"
-    mock_subprocess_run.return_value = MagicMock(
-        stdout="ffmpeg stdout", stderr=non_utf8_stderr.decode("utf-8", errors="replace")
-    )
-
-    # Act & Assert
-    try:
-        ts2mp4(input_file, output_file, crf, preset)
-    except UnicodeDecodeError:
-        pytest.fail("ts2mp4 should not raise UnicodeDecodeError")
-
-
-def test_raises_called_process_error_on_ffmpeg_failure(mocker: MockerFixture) -> None:
+def test_ts2mp4_propagates_called_process_error(mocker: MockerFixture) -> None:
     # Arrange
     input_file = Path("input.ts")
     output_file = Path("output.mp4")
@@ -123,8 +88,8 @@ def test_raises_called_process_error_on_ffmpeg_failure(mocker: MockerFixture) ->
     preset = "medium"
 
     mocker.patch("ts2mp4.ts2mp4.verify_audio_stream_integrity")
-    mock_subprocess_run = mocker.patch("subprocess.run")
-    mock_subprocess_run.side_effect = subprocess.CalledProcessError(
+    mock_execute_command = mocker.patch("ts2mp4.ts2mp4.execute_command")
+    mock_execute_command.side_effect = subprocess.CalledProcessError(
         returncode=1, cmd="ffmpeg"
     )
 
@@ -133,7 +98,7 @@ def test_raises_called_process_error_on_ffmpeg_failure(mocker: MockerFixture) ->
         ts2mp4(input_file, output_file, crf, preset)
 
 
-def test_does_not_call_verify_audio_stream_integrity_on_ffmpeg_failure(
+def test_does_not_call_verify_audio_stream_integrity_on_failure(
     mocker: MockerFixture,
 ) -> None:
     # Arrange
@@ -142,11 +107,11 @@ def test_does_not_call_verify_audio_stream_integrity_on_ffmpeg_failure(
     crf = 23
     preset = "medium"
 
-    mock_subprocess_run = mocker.patch("subprocess.run")
+    mock_execute_command = mocker.patch("ts2mp4.ts2mp4.execute_command")
     mock_verify_audio_stream_integrity = mocker.patch(
         "ts2mp4.ts2mp4.verify_audio_stream_integrity"
     )
-    mock_subprocess_run.side_effect = subprocess.CalledProcessError(
+    mock_execute_command.side_effect = subprocess.CalledProcessError(
         returncode=1, cmd="ffmpeg"
     )
 
@@ -155,30 +120,3 @@ def test_does_not_call_verify_audio_stream_integrity_on_ffmpeg_failure(
         ts2mp4(input_file, output_file, crf, preset)
 
     mock_verify_audio_stream_integrity.assert_not_called()
-
-
-def test_logs_error_on_ffmpeg_failure(mocker: MockerFixture) -> None:
-    # Arrange
-    input_file = Path("input.ts")
-    output_file = Path("output.mp4")
-    crf = 23
-    preset = "medium"
-
-    mocker.patch("ts2mp4.ts2mp4.verify_audio_stream_integrity")
-    mock_subprocess_run = mocker.patch("subprocess.run")
-    mock_logger_error = mocker.patch("ts2mp4.ts2mp4.logger.error")
-    mock_logger_info = mocker.patch("ts2mp4.ts2mp4.logger.info")
-
-    error = subprocess.CalledProcessError(
-        returncode=1, cmd="ffmpeg", stderr="ffmpeg error"
-    )
-    error.stdout = "ffmpeg stdout"
-    mock_subprocess_run.side_effect = error
-
-    # Act & Assert
-    with pytest.raises(subprocess.CalledProcessError):
-        ts2mp4(input_file, output_file, crf, preset)
-
-    mock_logger_error.assert_any_call("FFmpeg failed to execute.")
-    mock_logger_info.assert_any_call("FFmpeg Stdout:\nffmpeg stdout")
-    mock_logger_info.assert_any_call("FFmpeg Stderr:\nffmpeg error")

--- a/ts2mp4/audio_integrity.py
+++ b/ts2mp4/audio_integrity.py
@@ -1,9 +1,10 @@
 import hashlib
 import json
-import subprocess
 from pathlib import Path
 
 from logzero import logger
+
+from .command import execute_command
 
 
 def _get_audio_stream_count(file_path: Path) -> int:
@@ -14,9 +15,6 @@ def _get_audio_stream_count(file_path: Path) -> int:
 
     Returns:
         The number of audio streams.
-
-    Raises:
-        RuntimeError: If ffprobe fails to get stream information.
     """
     command = [
         "ffprobe",
@@ -29,18 +27,7 @@ def _get_audio_stream_count(file_path: Path) -> int:
         "json",
         str(file_path),
     ]
-    try:
-        result = subprocess.run(
-            command,
-            stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE,
-            check=True,
-        )
-    except subprocess.CalledProcessError as e:
-        raise RuntimeError(
-            f"ffprobe failed to get stream information for {file_path}. Error: {e.stderr.decode()}"
-        ) from e
-
+    result = execute_command(command)
     data = json.loads(result.stdout)
     return sum(
         1 for stream in data.get("streams", []) if stream.get("codec_type") == "audio"
@@ -56,9 +43,6 @@ def _get_audio_stream_md5(file_path: Path, stream_index: int) -> str:
 
     Returns:
         The MD5 hash of the decoded audio stream as a hexadecimal string.
-
-    Raises:
-        RuntimeError: If FFmpeg fails to extract the audio stream.
     """
     command = [
         "ffmpeg",
@@ -72,18 +56,7 @@ def _get_audio_stream_md5(file_path: Path, stream_index: int) -> str:
         "s16le",  # Output raw signed 16-bit little-endian PCM
         "-",  # Output to stdout
     ]
-    try:
-        result = subprocess.run(
-            command,
-            stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE,
-            check=True,  # Raise CalledProcessError for non-zero exit codes
-        )
-    except subprocess.CalledProcessError as e:
-        raise RuntimeError(
-            f"FFmpeg failed to get decoded audio stream for {file_path}. Error: {e.stderr.decode()}"
-        ) from e
-
+    result = execute_command(command, text=False)
     return hashlib.md5(result.stdout).hexdigest()
 
 

--- a/ts2mp4/command.py
+++ b/ts2mp4/command.py
@@ -1,0 +1,52 @@
+import subprocess
+from typing import Any, Literal, Union, overload
+
+from logzero import logger
+
+
+@overload
+def execute_command(
+    command: list[str], text: Literal[True] = True
+) -> subprocess.CompletedProcess[str]: ...
+
+
+@overload
+def execute_command(
+    command: list[str], text: Literal[False]
+) -> subprocess.CompletedProcess[bytes]: ...
+
+
+def execute_command(
+    command: list[str], text: bool = True
+) -> Union[subprocess.CompletedProcess[str], subprocess.CompletedProcess[bytes]]:
+    """Executes a given command and returns the result.
+
+    Args:
+        command: A list of strings representing the command to execute.
+        text: If True, decode stdout and stderr as text.
+
+    Returns:
+        A CompletedProcess object with the results of the command.
+    """
+    logger.info(f"Running command: {' '.join(command)}")
+    run_kwargs: dict[str, Any] = {"capture_output": True, "check": False}
+    if text:
+        run_kwargs["text"] = True
+        run_kwargs["encoding"] = "utf-8"
+        run_kwargs["errors"] = "replace"
+
+    result = subprocess.run(command, **run_kwargs)
+
+    if text:
+        if result.stdout:
+            logger.info(result.stdout)
+        if result.stderr:
+            logger.error(result.stderr)
+    else:
+        # Assuming binary output might not be useful to log directly
+        pass
+    if result.returncode != 0:
+        raise subprocess.CalledProcessError(
+            result.returncode, result.args, result.stdout, result.stderr
+        )
+    return result

--- a/ts2mp4/ts2mp4.py
+++ b/ts2mp4/ts2mp4.py
@@ -1,9 +1,7 @@
-import subprocess
 from pathlib import Path
 
-from logzero import logger
-
 from .audio_integrity import verify_audio_stream_integrity
+from .command import execute_command
 
 
 def ts2mp4(input_file: Path, output_file: Path, crf: int, preset: str) -> None:
@@ -56,25 +54,6 @@ def ts2mp4(input_file: Path, output_file: Path, crf: int, preset: str) -> None:
         "aac_adtstoasc",
         str(output_file),
     ]
-    logger.info(f"FFmpeg Command: {' '.join(ffmpeg_command)}")
-
-    try:
-        process = subprocess.run(
-            args=ffmpeg_command,
-            check=True,
-            capture_output=True,
-            text=True,
-            encoding="utf-8",
-            errors="replace",
-        )
-        logger.info("FFmpeg Stdout:\n" + process.stdout)
-        logger.info("FFmpeg Stderr:\n" + process.stderr)
-    except subprocess.CalledProcessError as e:
-        logger.error("FFmpeg failed to execute.")
-        if e.stdout:
-            logger.info(f"FFmpeg Stdout:\n{e.stdout}")
-        if e.stderr:
-            logger.info(f"FFmpeg Stderr:\n{e.stderr}")
-        raise
+    execute_command(ffmpeg_command)
 
     verify_audio_stream_integrity(input_file=input_file, output_file=output_file)


### PR DESCRIPTION
This commit introduces a new `command` module to centralize the execution of external commands like `ffmpeg` and `ffprobe`.

Key changes:
- A new `execute_command` function handles running subprocesses, capturing their output, and logging it.
- Existing code in `ts2mp4` and `audio_integrity` modules is refactored to use `execute_command`.
- Integration tests for the `command` module are added, which execute actual commands to verify success, failure, and logging behavior.
- Tests for `ts2mp4` are updated to mock `execute_command`, aligning them with the new abstraction layer.
- Test names and responsibilities are clarified to improve maintainability.