### PR TITLE
Refactor: Improve ffmpeg command execution and error handling

### DIFF
--- a/tests/test_audio_integrity.py
+++ b/tests/test_audio_integrity.py
@@ -8,6 +8,7 @@ from ts2mp4.audio_integrity import (
     _get_audio_stream_md5,
     verify_audio_stream_integrity,
 )
+from ts2mp4.ffmpeg import FFmpegResult
 
 
 def test_get_audio_stream_count(ts_file: Path) -> None:
@@ -59,6 +60,26 @@ def test_verify_audio_stream_integrity_mismatch(mocker: MockerFixture) -> None:
         verify_audio_stream_integrity(input_file, output_file)
 
     assert "Audio stream MD5 mismatch!" in str(excinfo.value)
+
+
+def test_get_audio_stream_count_failure(mocker: MockerFixture, ts_file: Path) -> None:
+    """Test _get_audio_stream_count with a non-zero return code."""
+    mock_execute_ffprobe = mocker.patch("ts2mp4.audio_integrity.execute_ffprobe")
+    mock_execute_ffprobe.return_value = FFmpegResult(
+        stdout=b"", stderr="ffprobe error", returncode=1
+    )
+    with pytest.raises(RuntimeError, match="ffprobe failed"):
+        _get_audio_stream_count(ts_file)
+
+
+def test_get_audio_stream_md5_failure(mocker: MockerFixture, ts_file: Path) -> None:
+    """Test _get_audio_stream_md5 with a non-zero return code."""
+    mock_execute_ffmpeg = mocker.patch("ts2mp4.audio_integrity.execute_ffmpeg")
+    mock_execute_ffmpeg.return_value = FFmpegResult(
+        stdout=b"", stderr="ffmpeg error", returncode=1
+    )
+    with pytest.raises(RuntimeError, match="ffmpeg failed"):
+        _get_audio_stream_md5(ts_file, 0)
 
 
 def test_verify_audio_stream_integrity_no_audio_streams(

--- a/tests/test_ffmpeg.py
+++ b/tests/test_ffmpeg.py
@@ -1,0 +1,56 @@
+import io
+import logging
+from unittest.mock import MagicMock
+
+import logzero
+from pytest_mock import MockerFixture
+
+from ts2mp4.ffmpeg import execute_ffmpeg, execute_ffprobe
+
+
+def test_execute_ffmpeg_success() -> None:
+    """Test that execute_ffmpeg runs ffmpeg successfully."""
+    result = execute_ffmpeg(["-version"])
+    assert result.returncode == 0
+    assert b"ffmpeg version" in result.stdout or "ffmpeg version" in result.stderr
+
+
+def test_execute_ffmpeg_failure() -> None:
+    """Test that execute_ffmpeg returns a non-zero return code on failure."""
+    result = execute_ffmpeg(["-invalid_option"])
+    assert result.returncode != 0
+
+
+def test_execute_ffprobe_success() -> None:
+    """Test that execute_ffprobe runs ffprobe successfully."""
+    result = execute_ffprobe(["-version"])
+    assert result.returncode == 0
+    assert b"ffprobe version" in result.stdout or "ffprobe version" in result.stderr
+
+
+def test_handles_non_utf8_output(mocker: MockerFixture) -> None:
+    """Test that _execute_process handles non-UTF-8 output correctly."""
+    mock_popen = mocker.patch("subprocess.Popen")
+    mock_process = MagicMock()
+    mock_process.communicate.return_value = (b"", b"invalid byte: \xff")
+    mock_process.returncode = 0
+    mock_popen.return_value = mock_process
+
+    from ts2mp4.ffmpeg import _execute_process
+
+    result = _execute_process("ffmpeg", [])
+    assert "�" in result.stderr
+
+
+def test_logs_stderr_as_info() -> None:
+    """Test that the execution logs stderr as info."""
+    log_stream = io.StringIO()
+    handler = logging.StreamHandler(log_stream)
+    logzero.logger.addHandler(handler)
+    logzero.logger.setLevel(logging.INFO)
+
+    execute_ffmpeg(["-invalid_option"])
+
+    logzero.logger.removeHandler(handler)
+    log_contents = log_stream.getvalue()
+    assert "Unrecognized option" in log_contents

--- a/tests/test_ts2mp4.py
+++ b/tests/test_ts2mp4.py
@@ -1,33 +1,28 @@
-import subprocess
 from pathlib import Path
-from unittest.mock import MagicMock
 
 import pytest
 from pytest_mock import MockerFixture
 
+from ts2mp4.ffmpeg import FFmpegResult
 from ts2mp4.ts2mp4 import ts2mp4
 
 
-def test_calls_ffmpeg_with_correct_args(mocker: MockerFixture) -> None:
+def test_calls_execute_ffmpeg_with_correct_args(mocker: MockerFixture) -> None:
     # Arrange
     input_file = Path("input.ts")
     output_file = Path("output.mp4")
     crf = 23
     preset = "medium"
 
-    mock_subprocess_run = mocker.patch("subprocess.run")
+    mock_execute_ffmpeg = mocker.patch("ts2mp4.ts2mp4.execute_ffmpeg")
+    mock_execute_ffmpeg.return_value = FFmpegResult(stdout=b"", stderr="", returncode=0)
     mocker.patch("ts2mp4.ts2mp4.verify_audio_stream_integrity")
-
-    mock_subprocess_run.return_value = MagicMock(
-        stdout="ffmpeg stdout", stderr="ffmpeg stderr"
-    )
 
     # Act
     ts2mp4(input_file, output_file, crf, preset)
 
     # Assert
-    expected_command = [
-        "ffmpeg",
+    expected_args = [
         "-hide_banner",
         "-nostats",
         "-fflags",
@@ -61,14 +56,7 @@ def test_calls_ffmpeg_with_correct_args(mocker: MockerFixture) -> None:
         "aac_adtstoasc",
         str(output_file),
     ]
-    mock_subprocess_run.assert_called_once_with(
-        args=expected_command,
-        check=True,
-        capture_output=True,
-        text=True,
-        encoding="utf-8",
-        errors="replace",
-    )
+    mock_execute_ffmpeg.assert_called_once_with(expected_args)
 
 
 def test_calls_verify_audio_stream_integrity_on_success(mocker: MockerFixture) -> None:
@@ -78,7 +66,8 @@ def test_calls_verify_audio_stream_integrity_on_success(mocker: MockerFixture) -
     crf = 23
     preset = "medium"
 
-    mocker.patch("subprocess.run")
+    mock_execute_ffmpeg = mocker.patch("ts2mp4.ts2mp4.execute_ffmpeg")
+    mock_execute_ffmpeg.return_value = FFmpegResult(stdout=b"", stderr="", returncode=0)
     mock_verify_audio_stream_integrity = mocker.patch(
         "ts2mp4.ts2mp4.verify_audio_stream_integrity"
     )
@@ -92,30 +81,7 @@ def test_calls_verify_audio_stream_integrity_on_success(mocker: MockerFixture) -
     )
 
 
-def test_handles_non_utf8_ffmpeg_output(mocker: MockerFixture) -> None:
-    # Arrange
-    input_file = Path("input.ts")
-    output_file = Path("output.mp4")
-    crf = 23
-    preset = "medium"
-
-    mock_subprocess_run = mocker.patch("subprocess.run")
-    mocker.patch("ts2mp4.ts2mp4.verify_audio_stream_integrity")
-
-    # Simulate ffmpeg output with invalid UTF-8 bytes
-    non_utf8_stderr = b"ffmpeg stderr with invalid byte: \xc6"
-    mock_subprocess_run.return_value = MagicMock(
-        stdout="ffmpeg stdout", stderr=non_utf8_stderr.decode("utf-8", errors="replace")
-    )
-
-    # Act & Assert
-    try:
-        ts2mp4(input_file, output_file, crf, preset)
-    except UnicodeDecodeError:
-        pytest.fail("ts2mp4 should not raise UnicodeDecodeError")
-
-
-def test_raises_called_process_error_on_ffmpeg_failure(mocker: MockerFixture) -> None:
+def test_ts2mp4_raises_runtime_error_on_failure(mocker: MockerFixture) -> None:
     # Arrange
     input_file = Path("input.ts")
     output_file = Path("output.mp4")
@@ -123,17 +89,17 @@ def test_raises_called_process_error_on_ffmpeg_failure(mocker: MockerFixture) ->
     preset = "medium"
 
     mocker.patch("ts2mp4.ts2mp4.verify_audio_stream_integrity")
-    mock_subprocess_run = mocker.patch("subprocess.run")
-    mock_subprocess_run.side_effect = subprocess.CalledProcessError(
-        returncode=1, cmd="ffmpeg"
+    mock_execute_ffmpeg = mocker.patch("ts2mp4.ts2mp4.execute_ffmpeg")
+    mock_execute_ffmpeg.return_value = FFmpegResult(
+        stdout=b"", stderr="ffmpeg error", returncode=1
     )
 
     # Act & Assert
-    with pytest.raises(subprocess.CalledProcessError):
+    with pytest.raises(RuntimeError, match="ffmpeg failed with return code 1"):
         ts2mp4(input_file, output_file, crf, preset)
 
 
-def test_does_not_call_verify_audio_stream_integrity_on_ffmpeg_failure(
+def test_does_not_call_verify_audio_stream_integrity_on_failure(
     mocker: MockerFixture,
 ) -> None:
     # Arrange
@@ -142,43 +108,16 @@ def test_does_not_call_verify_audio_stream_integrity_on_ffmpeg_failure(
     crf = 23
     preset = "medium"
 
-    mock_subprocess_run = mocker.patch("subprocess.run")
+    mock_execute_ffmpeg = mocker.patch("ts2mp4.ts2mp4.execute_ffmpeg")
     mock_verify_audio_stream_integrity = mocker.patch(
         "ts2mp4.ts2mp4.verify_audio_stream_integrity"
     )
-    mock_subprocess_run.side_effect = subprocess.CalledProcessError(
-        returncode=1, cmd="ffmpeg"
+    mock_execute_ffmpeg.return_value = FFmpegResult(
+        stdout=b"", stderr="ffmpeg error", returncode=1
     )
 
     # Act & Assert
-    with pytest.raises(subprocess.CalledProcessError):
+    with pytest.raises(RuntimeError):
         ts2mp4(input_file, output_file, crf, preset)
 
     mock_verify_audio_stream_integrity.assert_not_called()
-
-
-def test_logs_error_on_ffmpeg_failure(mocker: MockerFixture) -> None:
-    # Arrange
-    input_file = Path("input.ts")
-    output_file = Path("output.mp4")
-    crf = 23
-    preset = "medium"
-
-    mocker.patch("ts2mp4.ts2mp4.verify_audio_stream_integrity")
-    mock_subprocess_run = mocker.patch("subprocess.run")
-    mock_logger_error = mocker.patch("ts2mp4.ts2mp4.logger.error")
-    mock_logger_info = mocker.patch("ts2mp4.ts2mp4.logger.info")
-
-    error = subprocess.CalledProcessError(
-        returncode=1, cmd="ffmpeg", stderr="ffmpeg error"
-    )
-    error.stdout = "ffmpeg stdout"
-    mock_subprocess_run.side_effect = error
-
-    # Act & Assert
-    with pytest.raises(subprocess.CalledProcessError):
-        ts2mp4(input_file, output_file, crf, preset)
-
-    mock_logger_error.assert_any_call("FFmpeg failed to execute.")
-    mock_logger_info.assert_any_call("FFmpeg Stdout:\nffmpeg stdout")
-    mock_logger_info.assert_any_call("FFmpeg Stderr:\nffmpeg error")

--- a/ts2mp4/ffmpeg.py
+++ b/ts2mp4/ffmpeg.py
@@ -1,0 +1,55 @@
+import subprocess
+from typing import Literal, NamedTuple
+
+from logzero import logger
+
+
+class FFmpegResult(NamedTuple):
+    stdout: bytes
+    stderr: str
+    returncode: int
+
+
+def _execute_process(
+    executable: Literal["ffmpeg", "ffprobe"], args: list[str]
+) -> FFmpegResult:
+    command = [executable] + args
+    logger.info(f"Running command: {' '.join(command)}")
+
+    process = subprocess.Popen(command, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    stdout, stderr_bytes = process.communicate()
+
+    # stdout is treated as binary data, as it can contain multimedia streams.
+    # stderr is treated as text, as it's used for logs and progress information.
+    stderr = stderr_bytes.decode("utf-8", errors="replace")
+
+    if stderr:
+        logger.info(stderr)
+
+    return FFmpegResult(stdout=stdout, stderr=stderr, returncode=process.returncode)
+
+
+def execute_ffmpeg(args: list[str]) -> FFmpegResult:
+    """
+    Executes ffmpeg and returns the result.
+
+    Args:
+        args: A list of arguments for the command.
+
+    Returns:
+        An FFmpegResult object with the command's results.
+    """
+    return _execute_process("ffmpeg", args)
+
+
+def execute_ffprobe(args: list[str]) -> FFmpegResult:
+    """
+    Executes ffprobe and returns the result.
+
+    Args:
+        args: A list of arguments for the command.
+
+    Returns:
+        An FFmpegResult object with the command's results.
+    """
+    return _execute_process("ffprobe", args)


### PR DESCRIPTION
This commit refactors the ffmpeg command execution logic for better usability, error handling, and testability.

- **Dedicated ffmpeg/ffprobe Functions:** Introduced `execute_ffmpeg` and `execute_ffprobe` in the `ffmpeg` module to centralize command execution.
- **Improved Error Handling:**
    - Replaced `subprocess.CalledProcessError` with `RuntimeError` for failed ffmpeg/ffprobe executions, providing more concise error messages.
    - Updated `_get_audio_stream_count`, `_get_audio_stream_md5`, and `ts2mp4` to catch the new `RuntimeError`.
- **Enhanced Testing:**
    - Added `test_ffmpeg.py` to unit test `execute_ffmpeg` and `execute_ffprobe`, including non-UTF-8 output scenarios.
    - Strengthened `test_audio_integrity.py` with tests for ffmpeg/ffprobe failures and restored integration tests.
    - Adapted `test_ts2mp4.py` to the new execution functions and error handling.
