### PR TITLE
feat: Clean up log files generated in e2e tests

### DIFF
--- a/tests/test_e2e.py
+++ b/tests/test_e2e.py
@@ -6,13 +6,23 @@ import pytest
 
 
 @pytest.fixture(autouse=True)
-def cleanup_mp4_file(mp4_file: Path) -> Generator[None, None, None]:
-    """Ensures the .mp4 file is removed before and after each test."""
+def cleanup_files(mp4_file: Path) -> Generator[None, None, None]:
+    """Ensures the .mp4 and .log files are removed before and after each test."""
     if mp4_file.exists():
         mp4_file.unlink()
+
+    log_files = list(mp4_file.parent.glob("*.log"))
+    for log_file in log_files:
+        log_file.unlink()
+
     yield
+
     if mp4_file.exists():
         mp4_file.unlink()
+
+    log_files = list(mp4_file.parent.glob("*.log"))
+    for log_file in log_files:
+        log_file.unlink()
 
 
 def test_ts2mp4_conversion_success(

--- a/tests/test_e2e.py
+++ b/tests/test_e2e.py
@@ -11,7 +11,7 @@ def cleanup_files(mp4_file: Path) -> Generator[None, None, None]:
 
     def _cleanup() -> None:
         mp4_file.unlink(missing_ok=True)
-        for log_file in mp4_file.parent.glob("*.log"):
+        for log_file in mp4_file.parent.glob(f"{mp4_file.stem}*.log"):
             log_file.unlink(missing_ok=True)
 
     _cleanup()

--- a/tests/test_e2e.py
+++ b/tests/test_e2e.py
@@ -10,11 +10,9 @@ def cleanup_files(mp4_file: Path) -> Generator[None, None, None]:
     """Ensures the .mp4 and .log files are removed before and after each test."""
 
     def _cleanup() -> None:
-        if mp4_file.exists():
-            mp4_file.unlink()
-
+        mp4_file.unlink(missing_ok=True)
         for log_file in mp4_file.parent.glob("*.log"):
-            log_file.unlink()
+            log_file.unlink(missing_ok=True)
 
     _cleanup()
     yield

--- a/tests/test_e2e.py
+++ b/tests/test_e2e.py
@@ -8,21 +8,17 @@ import pytest
 @pytest.fixture(autouse=True)
 def cleanup_files(mp4_file: Path) -> Generator[None, None, None]:
     """Ensures the .mp4 and .log files are removed before and after each test."""
-    if mp4_file.exists():
-        mp4_file.unlink()
 
-    log_files = list(mp4_file.parent.glob("*.log"))
-    for log_file in log_files:
-        log_file.unlink()
+    def _cleanup() -> None:
+        if mp4_file.exists():
+            mp4_file.unlink()
 
+        for log_file in mp4_file.parent.glob("*.log"):
+            log_file.unlink()
+
+    _cleanup()
     yield
-
-    if mp4_file.exists():
-        mp4_file.unlink()
-
-    log_files = list(mp4_file.parent.glob("*.log"))
-    for log_file in log_files:
-        log_file.unlink()
+    _cleanup()
 
 
 def test_ts2mp4_conversion_success(


### PR DESCRIPTION
This commit fixes an issue where log files generated during e2e tests were not being removed after the tests completed.

The `cleanup_files` fixture in `tests/test_e2e.py` has been updated to delete `.log` files in the `tests/assets` directory before and after each test run.