### PR TITLE
feat(tests): Introduce test classification and strategy with pytest m…

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,8 +6,12 @@ check: $(TEST_ASSETS_DIR)/test_video.ts
 	poetry run isort --check .
 	poetry run flake8 .
 	poetry run mypy .
-	poetry run pytest --ignore=tests/test_e2e.py
-	poetry run pytest tests/test_e2e.py
+	@echo "Running unit tests..."
+	poetry run pytest -m unit
+	@echo "Running integration tests..."
+	poetry run pytest -m integration
+	@echo "Running E2E tests..."
+	poetry run pytest -m e2e
 
 .PHONY: format
 format:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,6 +30,13 @@ pydocstyle = "^6.3.0"
 pytest = "^8.4.1"
 pytest-mock = "^3.14.1"
 
+[tool.pytest.ini_options]
+markers = [
+    "unit: mark a test as a unit test.",
+    "integration: mark a test as an integration test.",
+    "e2e: mark a test as an end-to-end test.",
+]
+
 [tool.poetry.scripts]
 ts2mp4 = "ts2mp4.cli:app"
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,6 +2,32 @@ from pathlib import Path
 
 import pytest
 
+ALLOWED_MARKERS = {"unit", "integration", "e2e"}
+
+
+def pytest_collection_modifyitems(
+    session: pytest.Session, items: list[pytest.Item]
+) -> None:
+    """
+    Validate that every test is marked with exactly one of the allowed markers.
+    """
+    sorted_markers = sorted(list(ALLOWED_MARKERS))
+
+    for item in items:
+        markers = {marker.name for marker in item.iter_markers()}
+        intersecting_markers = markers.intersection(ALLOWED_MARKERS)
+
+        if len(intersecting_markers) == 0:
+            pytest.fail(
+                f"Test item '{item.nodeid}' is missing a required mark. "
+                f"Please add one of: @pytest.mark.{', @pytest.mark.'.join(sorted_markers)}"
+            )
+        elif len(intersecting_markers) > 1:
+            pytest.fail(
+                f"Test item '{item.nodeid}' has multiple classification marks: {intersecting_markers}. "
+                f"Please specify exactly one of: @pytest.mark.{', @pytest.mark.'.join(sorted_markers)}"
+            )
+
 
 @pytest.fixture(scope="session")
 def project_root() -> Path:

--- a/tests/test_audio_integrity.py
+++ b/tests/test_audio_integrity.py
@@ -11,6 +11,7 @@ from ts2mp4.audio_integrity import (
 from ts2mp4.ffmpeg import FFmpegResult
 
 
+@pytest.mark.integration
 def test_get_audio_stream_count(ts_file: Path) -> None:
     """Test the _get_audio_stream_count helper function."""
     expected_stream_count = 1
@@ -18,6 +19,7 @@ def test_get_audio_stream_count(ts_file: Path) -> None:
     assert actual_stream_count == expected_stream_count
 
 
+@pytest.mark.integration
 def test_get_audio_stream_md5(ts_file: Path) -> None:
     """Test the _get_audio_stream_md5 helper function."""
     expected_md5 = "9db9dd4cb46b9678894578946158955b"
@@ -25,6 +27,7 @@ def test_get_audio_stream_md5(ts_file: Path) -> None:
     assert actual_md5 == expected_md5
 
 
+@pytest.mark.unit
 def test_verify_audio_stream_integrity_matches(mocker: MockerFixture) -> None:
     input_file = Path("dummy_input.ts")
     output_file = Path("dummy_output.mp4.part")
@@ -43,6 +46,7 @@ def test_verify_audio_stream_integrity_matches(mocker: MockerFixture) -> None:
     verify_audio_stream_integrity(input_file, output_file)
 
 
+@pytest.mark.unit
 def test_verify_audio_stream_integrity_mismatch(mocker: MockerFixture) -> None:
     input_file = Path("dummy_input.ts")
     output_file = Path("dummy_output.mp4.part")
@@ -62,6 +66,7 @@ def test_verify_audio_stream_integrity_mismatch(mocker: MockerFixture) -> None:
     assert "Audio stream MD5 mismatch!" in str(excinfo.value)
 
 
+@pytest.mark.unit
 def test_get_audio_stream_count_failure(mocker: MockerFixture, ts_file: Path) -> None:
     """Test _get_audio_stream_count with a non-zero return code."""
     mock_execute_ffprobe = mocker.patch("ts2mp4.audio_integrity.execute_ffprobe")
@@ -72,6 +77,7 @@ def test_get_audio_stream_count_failure(mocker: MockerFixture, ts_file: Path) ->
         _get_audio_stream_count(ts_file)
 
 
+@pytest.mark.unit
 def test_get_audio_stream_md5_failure(mocker: MockerFixture, ts_file: Path) -> None:
     """Test _get_audio_stream_md5 with a non-zero return code."""
     mock_execute_ffmpeg = mocker.patch("ts2mp4.audio_integrity.execute_ffmpeg")
@@ -82,6 +88,7 @@ def test_get_audio_stream_md5_failure(mocker: MockerFixture, ts_file: Path) -> N
         _get_audio_stream_md5(ts_file, 0)
 
 
+@pytest.mark.unit
 def test_verify_audio_stream_integrity_no_audio_streams(
     mocker: MockerFixture,
 ) -> None:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -6,6 +6,7 @@ from freezegun import freeze_time
 from pytest_mock import MockerFixture
 
 
+@pytest.mark.integration
 @pytest.mark.parametrize(
     "command",
     [
@@ -21,6 +22,7 @@ def test_cli_entry_points_start_correctly(command: list[str]) -> None:
     assert "Usage:" in result.stdout
 
 
+@pytest.mark.integration
 def test_cli_options_recognized(mocker: MockerFixture, tmp_path: Path) -> None:
     """Test that the CLI recognizes the --crf and --preset options."""
     mock_ts2mp4 = mocker.patch("ts2mp4.ts2mp4.ts2mp4")
@@ -52,6 +54,7 @@ def test_cli_options_recognized(mocker: MockerFixture, tmp_path: Path) -> None:
     )
 
 
+@pytest.mark.integration
 def test_cli_invalid_crf_value(tmp_path: Path) -> None:
     """Test that the CLI handles invalid CRF values gracefully."""
     dummy_ts_path = tmp_path / "dummy.ts"
@@ -68,6 +71,7 @@ def test_cli_invalid_crf_value(tmp_path: Path) -> None:
     assert result.returncode != 0
 
 
+@pytest.mark.integration
 def test_cli_invalid_preset_value(mocker: MockerFixture, tmp_path: Path) -> None:
     """Test that the CLI handles invalid preset values gracefully."""
     mock_ts2mp4 = mocker.patch("ts2mp4.ts2mp4.ts2mp4")
@@ -93,6 +97,7 @@ def test_cli_invalid_preset_value(mocker: MockerFixture, tmp_path: Path) -> None
     mock_ts2mp4.assert_not_called()
 
 
+@pytest.mark.integration
 @freeze_time("2023-01-01 12:00:00")
 def test_log_file_creation(mocker: MockerFixture, tmp_path: Path) -> None:
     """Test that a log file is created with the correct naming convention."""

--- a/tests/test_e2e.py
+++ b/tests/test_e2e.py
@@ -15,6 +15,7 @@ def cleanup_mp4_file(mp4_file: Path) -> Generator[None, None, None]:
         mp4_file.unlink()
 
 
+@pytest.mark.e2e
 def test_ts2mp4_conversion_success(
     ts_file: Path, mp4_file: Path, project_root: Path
 ) -> None:
@@ -26,6 +27,7 @@ def test_ts2mp4_conversion_success(
     assert mp4_file.stat().st_size > 0
 
 
+@pytest.mark.e2e
 def test_ts2mp4_file_not_found_error(mp4_file: Path, project_root: Path) -> None:
     """Test error handling when the input .ts file does not exist."""
     non_existent_file = project_root / "non_existent.ts"
@@ -35,6 +37,7 @@ def test_ts2mp4_file_not_found_error(mp4_file: Path, project_root: Path) -> None
     assert not mp4_file.exists()
 
 
+@pytest.mark.e2e
 def test_ts2mp4_no_input_file_error(mp4_file: Path, project_root: Path) -> None:
     """Test error handling when no input file is provided."""
     command = ["poetry", "run", "ts2mp4"]

--- a/tests/test_ffmpeg.py
+++ b/tests/test_ffmpeg.py
@@ -3,11 +3,13 @@ import logging
 from unittest.mock import MagicMock
 
 import logzero
+import pytest
 from pytest_mock import MockerFixture
 
 from ts2mp4.ffmpeg import execute_ffmpeg, execute_ffprobe
 
 
+@pytest.mark.integration
 def test_execute_ffmpeg_success() -> None:
     """Test that execute_ffmpeg runs ffmpeg successfully."""
     result = execute_ffmpeg(["-version"])
@@ -15,12 +17,14 @@ def test_execute_ffmpeg_success() -> None:
     assert b"ffmpeg version" in result.stdout or "ffmpeg version" in result.stderr
 
 
+@pytest.mark.integration
 def test_execute_ffmpeg_failure() -> None:
     """Test that execute_ffmpeg returns a non-zero return code on failure."""
     result = execute_ffmpeg(["-invalid_option"])
     assert result.returncode != 0
 
 
+@pytest.mark.integration
 def test_execute_ffprobe_success() -> None:
     """Test that execute_ffprobe runs ffprobe successfully."""
     result = execute_ffprobe(["-version"])
@@ -28,6 +32,7 @@ def test_execute_ffprobe_success() -> None:
     assert b"ffprobe version" in result.stdout or "ffprobe version" in result.stderr
 
 
+@pytest.mark.integration
 def test_handles_non_utf8_output(mocker: MockerFixture) -> None:
     """Test that _execute_process handles non-UTF-8 output correctly."""
     mock_popen = mocker.patch("subprocess.Popen")
@@ -42,6 +47,7 @@ def test_handles_non_utf8_output(mocker: MockerFixture) -> None:
     assert "�" in result.stderr
 
 
+@pytest.mark.integration
 def test_logs_stderr_as_info() -> None:
     """Test that the execution logs stderr as info."""
     log_stream = io.StringIO()

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -1,15 +1,18 @@
 import importlib.metadata
 
+import pytest
 from pytest_mock import MockerFixture
 
 from ts2mp4 import _get_ts2mp4_version
 
 
+@pytest.mark.unit
 def test_get_ts2mp4_version_success(mocker: MockerFixture) -> None:
     mocker.patch("importlib.metadata.version", return_value="1.2.3")
     assert _get_ts2mp4_version() == "1.2.3"
 
 
+@pytest.mark.unit
 def test_get_ts2mp4_version_package_not_found(mocker: MockerFixture) -> None:
     mocker.patch(
         "importlib.metadata.version",

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -1,7 +1,10 @@
 import subprocess
 from pathlib import Path
 
+import pytest
 
+
+@pytest.mark.e2e
 def test_log_file_creation_and_content(tmp_path: Path, project_root: Path) -> None:
     """Test that a log file is created and contains expected messages."""
 

--- a/tests/test_ts2mp4.py
+++ b/tests/test_ts2mp4.py
@@ -7,6 +7,7 @@ from ts2mp4.ffmpeg import FFmpegResult
 from ts2mp4.ts2mp4 import ts2mp4
 
 
+@pytest.mark.unit
 def test_calls_execute_ffmpeg_with_correct_args(mocker: MockerFixture) -> None:
     # Arrange
     input_file = Path("input.ts")
@@ -59,6 +60,7 @@ def test_calls_execute_ffmpeg_with_correct_args(mocker: MockerFixture) -> None:
     mock_execute_ffmpeg.assert_called_once_with(expected_args)
 
 
+@pytest.mark.unit
 def test_calls_verify_audio_stream_integrity_on_success(mocker: MockerFixture) -> None:
     # Arrange
     input_file = Path("input.ts")
@@ -81,6 +83,7 @@ def test_calls_verify_audio_stream_integrity_on_success(mocker: MockerFixture) -
     )
 
 
+@pytest.mark.unit
 def test_ts2mp4_raises_runtime_error_on_failure(mocker: MockerFixture) -> None:
     # Arrange
     input_file = Path("input.ts")
@@ -99,6 +102,7 @@ def test_ts2mp4_raises_runtime_error_on_failure(mocker: MockerFixture) -> None:
         ts2mp4(input_file, output_file, crf, preset)
 
 
+@pytest.mark.unit
 def test_does_not_call_verify_audio_stream_integrity_on_failure(
     mocker: MockerFixture,
 ) -> None:


### PR DESCRIPTION
…arkers

To improve test maintainability and development efficiency, this change introduces a test classification system using pytest markers and a corresponding execution strategy.

- **Test Classification with Markers:**
  - Each test case is now marked with `@pytest.mark.unit`, `@pytest.mark.integration`, or `@pytest.mark.e2e` according to its scope.
  - This clarifies the purpose of each test without relying on directory structure.
  - For files containing mixed test types, like `test_audio_integrity.py`, each test function has been marked individually.

- **Pytest Configuration:**
  - Custom marker definitions have been added to `pyproject.toml` to prevent pytest warnings.

- **Makefile Enhancement:**
  - The `make check` command now runs tests in a strategic order: `unit` -> `integration` -> `e2e`. This is designed to provide faster feedback by running quicker, more isolated tests first.
  - A final step has been added to detect any tests that have not been assigned a marker (`not unit and not integration and not e2e`). This step is expected to find 0 tests (exit code 5), ensuring that all tests are explicitly classified and preventing unmarked tests from being overlooked.