### PR TITLE
feat: Implement audio stream integrity check and repair

### DIFF
--- a/tests/test_audio_repair.py
+++ b/tests/test_audio_repair.py
@@ -1,0 +1,151 @@
+from pathlib import Path
+
+import pytest
+from pytest_mock import MockerFixture
+
+from ts2mp4.audio_repair import (
+    _build_ffmpeg_args,
+    _get_audio_stream_codec,
+    reencode_and_replace_audio_streams,
+)
+from ts2mp4.ffmpeg import FFmpegResult, execute_ffmpeg
+from ts2mp4.ts2mp4 import ts2mp4
+
+
+def test_build_ffmpeg_args(mocker: MockerFixture, tmp_path: Path) -> None:
+    """
+    Test the _build_ffmpeg_args helper function.
+
+    This test case arranges a scenario where:
+    - The input video has two audio streams.
+    - The first audio stream (index 0) has failed the integrity check.
+    - The second audio stream (index 1) has passed.
+
+    The assertion checks whether the ffmpeg arguments are constructed correctly to:
+    - Re-encode the failed stream (index 0) from the original TS file (input 1).
+    - Copy the passed stream (index 1) from the intermediate MP4 file (input 0).
+    """
+    mocker.patch("ts2mp4.audio_repair._get_audio_stream_codec", return_value="aac")
+    mocker.patch("ts2mp4.audio_integrity._get_audio_stream_count", return_value=2)
+    mocker.patch(
+        "ts2mp4.audio_integrity.execute_ffprobe",
+        return_value=FFmpegResult(
+            stdout=b'{"streams": [{"codec_type": "audio"}, {"codec_type": "audio"}]}',
+            stderr="",
+            returncode=0,
+        ),
+    )
+
+    original_ts_file = tmp_path / "dummy.ts"
+    output_mp4_file = tmp_path / "dummy.mp4"
+    temp_output_file = output_mp4_file.with_suffix(".temp.mp4")
+    failed_stream_indices = [0]
+
+    ffmpeg_args = _build_ffmpeg_args(
+        original_ts_file,
+        output_mp4_file,
+        failed_stream_indices,
+        temp_output_file,
+    )
+
+    assert "-map" in ffmpeg_args
+    assert "1:a:0" in ffmpeg_args  # Failed stream re-encoded from original
+    assert "0:a:1" in ffmpeg_args  # Passed stream copied from intermediate
+
+
+def test_reencode_and_replace_audio_streams(
+    mocker: MockerFixture, tmp_path: Path
+) -> None:
+    """Test the reencode_and_replace_audio_streams function."""
+    mock_execute_ffmpeg = mocker.patch(
+        "ts2mp4.audio_repair.execute_ffmpeg",
+        return_value=FFmpegResult(stdout=b"", stderr="", returncode=0),
+    )
+    mocker.patch(
+        "ts2mp4.audio_repair._build_ffmpeg_args", return_value=["-y", "dummy_args"]
+    )
+
+    original_ts_file = tmp_path / "dummy.ts"
+    output_mp4_file = tmp_path / "dummy.mp4"
+    temp_output_file = output_mp4_file.with_suffix(".temp.mp4")
+    original_ts_file.touch()
+    output_mp4_file.touch()
+    temp_output_file.touch()
+    failed_stream_indices = [0]
+
+    reencode_and_replace_audio_streams(
+        original_ts_file, output_mp4_file, failed_stream_indices
+    )
+
+    mock_execute_ffmpeg.assert_called_once_with(["-y", "dummy_args"])
+
+
+def test_reencode_and_replace_audio_streams_no_failed_streams(
+    mocker: MockerFixture,
+) -> None:
+    """Test that reencode_and_replace_audio_streams does nothing when no streams failed."""
+    mock_execute_ffmpeg = mocker.patch("ts2mp4.audio_repair.execute_ffmpeg")
+
+    original_ts_file = Path("dummy.ts")
+    output_mp4_file = Path("dummy.mp4")
+    failed_stream_indices: list[int] = []
+
+    reencode_and_replace_audio_streams(
+        original_ts_file, output_mp4_file, failed_stream_indices
+    )
+
+    mock_execute_ffmpeg.assert_not_called()
+
+
+def test_get_audio_stream_codec(mocker: MockerFixture, ts_file: Path) -> None:
+    """Test the _get_audio_stream_codec helper function."""
+    mock_execute_ffprobe = mocker.patch("ts2mp4.audio_repair.execute_ffprobe")
+    mock_execute_ffprobe.return_value = FFmpegResult(
+        stdout=b'{"streams": [{"codec_name": "aac"}]}', stderr="", returncode=0
+    )
+    codec = _get_audio_stream_codec(ts_file, 0)
+    assert codec == "aac"
+
+
+def test_get_audio_stream_codec_failure(mocker: MockerFixture, ts_file: Path) -> None:
+    """Test _get_audio_stream_codec with a non-zero return code."""
+    mock_execute_ffprobe = mocker.patch("ts2mp4.audio_repair.execute_ffprobe")
+    mock_execute_ffprobe.return_value = FFmpegResult(
+        stdout=b"", stderr="ffprobe error", returncode=1
+    )
+    with pytest.raises(RuntimeError, match="ffprobe failed"):
+        _get_audio_stream_codec(ts_file, 0)
+
+
+def test_get_audio_stream_codec_with_real_video(ts_file: Path) -> None:
+    """Test _get_audio_stream_codec with a real video file."""
+    codec = _get_audio_stream_codec(ts_file, 0)
+    assert codec == "aac"
+
+
+def test_reencode_and_replace_audio_streams_with_real_video(
+    tmp_path: Path, ts_file: Path
+) -> None:
+    """Test reencode_and_replace_audio_streams with a real video file."""
+    output_mp4_file = tmp_path / "output.mp4"
+    ts2mp4(ts_file, output_mp4_file, crf=23, preset="medium")
+    assert output_mp4_file.exists()
+
+    reencode_and_replace_audio_streams(
+        original_ts_file=ts_file,
+        output_mp4_file=output_mp4_file,
+        failed_stream_indices=[0],
+    )
+
+    # Verify that the audio stream has been re-encoded
+    ffmpeg_args = [
+        "-i",
+        str(output_mp4_file),
+        "-map",
+        "0:a:0",
+        "-f",
+        "null",
+        "-",
+    ]
+    result = execute_ffmpeg(ffmpeg_args)
+    assert result.returncode == 0

--- a/ts2mp4/audio_repair.py
+++ b/ts2mp4/audio_repair.py
@@ -1,0 +1,135 @@
+import json
+from pathlib import Path
+
+from logzero import logger
+
+from .audio_integrity import _get_audio_stream_count
+from .ffmpeg import execute_ffmpeg, execute_ffprobe
+
+
+def _get_audio_stream_codec(file_path: Path, stream_index: int) -> str:
+    """Returns the codec name of a specific audio stream.
+
+    Args:
+        file_path: The path to the input file.
+        stream_index: The index of the audio stream.
+
+    Returns:
+        The codec name of the audio stream.
+
+    Raises:
+        RuntimeError: If ffprobe fails to get stream information.
+    """
+    ffprobe_args = [
+        "-v",
+        "error",
+        "-select_streams",
+        f"a:{stream_index}",
+        "-show_entries",
+        "stream=codec_name",
+        "-of",
+        "json",
+        str(file_path),
+    ]
+    result = execute_ffprobe(ffprobe_args)
+    if result.returncode != 0:
+        raise RuntimeError(
+            f"ffprobe failed to get codec for {file_path} stream a:{stream_index}. "
+            f"Return code: {result.returncode}"
+        )
+    data = json.loads(result.stdout.decode("utf-8"))
+    return str(data["streams"][0]["codec_name"])
+
+
+def _build_ffmpeg_args(
+    original_ts_file: Path,
+    output_mp4_file: Path,
+    failed_stream_indices: list[int],
+    temp_output_file: Path,
+) -> list[str]:
+    """Builds the ffmpeg command arguments for re-encoding and replacing streams."""
+    ffmpeg_args = [
+        "-y",
+        "-i",
+        str(output_mp4_file),
+        "-i",
+        str(original_ts_file),
+        "-map",
+        "0:v:0",
+        "-map",
+        "0:s?",
+    ]
+
+    # Stream mapping
+    map_args = []
+    codec_args = []
+
+    # Audio streams
+    audio_stream_count = _get_audio_stream_count(original_ts_file)
+
+    audio_output_index = 0
+    for i in range(audio_stream_count):
+        if i in failed_stream_indices:
+            # Re-encode from original TS file
+            codec = _get_audio_stream_codec(original_ts_file, i)
+            map_args.extend(["-map", f"1:a:{i}"])
+            codec_args.extend(["-c:a", codec])
+        else:
+            # Copy from existing MP4 file
+            map_args.extend(["-map", f"0:a:{i}"])
+            codec_args.extend(["-c:a", "copy"])
+        audio_output_index += 1
+
+    ffmpeg_args.extend(map_args)
+    ffmpeg_args.extend(codec_args)
+
+    ffmpeg_args.extend(
+        [
+            "-codec:v",
+            "copy",
+            "-codec:s",
+            "copy",
+            str(temp_output_file),
+        ]
+    )
+    return ffmpeg_args
+
+
+def reencode_and_replace_audio_streams(
+    original_ts_file: Path,
+    output_mp4_file: Path,
+    failed_stream_indices: list[int],
+) -> None:
+    """Re-encodes and replaces specified audio streams in an MP4 file.
+
+    Args:
+        original_ts_file: Path to the original TS file.
+        output_mp4_file: Path to the output MP4 file to be repaired.
+        failed_stream_indices: List of audio stream indices to re-encode and replace.
+    """
+    if not failed_stream_indices:
+        logger.info("No failed audio streams to re-encode.")
+        return
+
+    logger.info(
+        f"Re-encoding and replacing failed audio streams: {failed_stream_indices}"
+    )
+
+    temp_output_file = output_mp4_file.with_suffix(".temp.mp4")
+    ffmpeg_args = _build_ffmpeg_args(
+        original_ts_file,
+        output_mp4_file,
+        failed_stream_indices,
+        temp_output_file,
+    )
+
+    result = execute_ffmpeg(ffmpeg_args)
+    if result.returncode != 0:
+        raise RuntimeError(
+            f"ffmpeg failed to re-encode and replace audio streams. "
+            f"Return code: {result.returncode}"
+        )
+
+    output_mp4_file.unlink()
+    temp_output_file.rename(output_mp4_file)
+    logger.info("Successfully re-encoded and replaced failed audio streams.")

--- a/ts2mp4/ts2mp4.py
+++ b/ts2mp4/ts2mp4.py
@@ -1,6 +1,7 @@
 from pathlib import Path
 
-from .audio_integrity import verify_audio_stream_integrity
+from .audio_integrity import get_failed_audio_stream_indices_by_integrity_check
+from .audio_repair import reencode_and_replace_audio_streams
 from .ffmpeg import execute_ffmpeg
 
 
@@ -57,4 +58,12 @@ def ts2mp4(input_file: Path, output_file: Path, crf: int, preset: str) -> None:
     if result.returncode != 0:
         raise RuntimeError(f"ffmpeg failed with return code {result.returncode}")
 
-    verify_audio_stream_integrity(input_file=input_file, output_file=output_file)
+    failed_streams = get_failed_audio_stream_indices_by_integrity_check(
+        input_file=input_file, output_file=output_file
+    )
+    if failed_streams:
+        reencode_and_replace_audio_streams(
+            original_ts_file=input_file,
+            output_mp4_file=output_file,
+            failed_stream_indices=failed_streams,
+        )


### PR DESCRIPTION
Refactor audio integrity check and introduce audio stream repair functionality.

- Rename `verify_audio_stream_integrity` to `get_failed_audio_stream_indices_by_integrity_check` in `ts2mp4/audio_integrity.py`. This function now returns failed stream indices instead of raising an error.
- Add `ts2mp4/audio_repair.py` with `_get_audio_stream_codec`, `_build_ffmpeg_args`, and `reencode_and_replace_audio_streams` for repairing audio streams.
- Update `ts2mp4/ts2mp4.py` to use the new integrity check and call the audio repair function for failed streams.
- Update and add tests in `tests/test_audio_integrity.py`, `tests/test_ts2mp4.py`, and `tests/test_audio_repair.py` to cover these changes.
