### PR TITLE
Refactor: Improve test cleanup in e2e tests

### DIFF
--- a/tests/test_e2e.py
+++ b/tests/test_e2e.py
@@ -11,8 +11,9 @@ def cleanup_files(mp4_file: Path) -> Generator[None, None, None]:
 
     def _cleanup() -> None:
         mp4_file.unlink(missing_ok=True)
-        for log_file in mp4_file.parent.glob(f"{mp4_file.stem}-*.log"):
-            log_file.unlink(missing_ok=True)
+        for log_file in mp4_file.parent.glob("*.log"):
+            if log_file.stem.startswith(f"{mp4_file.stem}-"):
+                log_file.unlink(missing_ok=True)
 
     _cleanup()
     yield

--- a/tests/test_e2e.py
+++ b/tests/test_e2e.py
@@ -6,13 +6,17 @@ import pytest
 
 
 @pytest.fixture(autouse=True)
-def cleanup_mp4_file(mp4_file: Path) -> Generator[None, None, None]:
-    """Ensures the .mp4 file is removed before and after each test."""
-    if mp4_file.exists():
-        mp4_file.unlink()
+def cleanup_files(mp4_file: Path) -> Generator[None, None, None]:
+    """Ensures the .mp4 and .log files are removed before and after each test."""
+
+    def _cleanup() -> None:
+        mp4_file.unlink(missing_ok=True)
+        for log_file in mp4_file.parent.glob(f"{mp4_file.stem}-*.log"):
+            log_file.unlink(missing_ok=True)
+
+    _cleanup()
     yield
-    if mp4_file.exists():
-        mp4_file.unlink()
+    _cleanup()
 
 
 def test_ts2mp4_conversion_success(


### PR DESCRIPTION
- Rename `cleanup_mp4_file` fixture to `cleanup_files` for broader scope.
- Extend cleanup to remove associated `.log` files in addition to `.mp4` files.
- Use `missing_ok=True` for `unlink` operations to prevent errors if files don't exist.
- Encapsulate cleanup logic in a helper function for better readability and reusability within the fixture.
