### PR TITLE
Refactor: Improve audio stream integrity verification

### DIFF
--- a/tests/test_audio_integrity.py
+++ b/tests/test_audio_integrity.py
@@ -5,7 +5,7 @@ from pytest_mock import MockerFixture
 
 from ts2mp4.audio_integrity import (
     _get_audio_stream_count,
-    verify_audio_stream_integrity,
+    get_mismatched_audio_stream_indices,
 )
 
 
@@ -18,7 +18,8 @@ def test_get_audio_stream_count(ts_file: Path) -> None:
 
 
 @pytest.mark.unit
-def test_verify_audio_stream_integrity_matches(mocker: MockerFixture) -> None:
+def test_get_mismatched_audio_stream_indices_matches(mocker: MockerFixture) -> None:
+    """Tests that an empty list is returned when all stream hashes match."""
     input_file = Path("dummy_input.ts")
     output_file = Path("dummy_output.mp4.part")
 
@@ -27,33 +28,64 @@ def test_verify_audio_stream_integrity_matches(mocker: MockerFixture) -> None:
         "ts2mp4.audio_integrity.get_stream_md5",
         side_effect=[
             "hash1_input",
-            "hash2_input",  # input_file のMD5
             "hash1_input",
-            "hash2_input",  # output_file のMD5 (一致)
+            "hash2_input",
+            "hash2_input",
         ],
     )
 
-    verify_audio_stream_integrity(input_file, output_file)
+    result = get_mismatched_audio_stream_indices(input_file, output_file)
+    assert result == []
 
 
 @pytest.mark.unit
-def test_verify_audio_stream_integrity_mismatch(mocker: MockerFixture) -> None:
+def test_get_mismatched_audio_stream_indices_mismatch(mocker: MockerFixture) -> None:
+    """Tests that a list of mismatched indices is returned correctly."""
     input_file = Path("dummy_input.ts")
     output_file = Path("dummy_output.mp4.part")
 
-    mocker.patch("ts2mp4.audio_integrity._get_audio_stream_count", return_value=1)
+    mocker.patch("ts2mp4.audio_integrity._get_audio_stream_count", return_value=3)
     mocker.patch(
         "ts2mp4.audio_integrity.get_stream_md5",
         side_effect=[
-            "hash_input",  # input_file のMD5
-            "hash_output",  # output_file のMD5 (不一致)
+            "hash1_input",
+            "hash1_input",  # Match
+            "hash2_input",
+            "hash2_output",  # Mismatch
+            "hash3_input",
+            "hash3_input",  # Match
         ],
     )
 
-    with pytest.raises(RuntimeError) as excinfo:
-        verify_audio_stream_integrity(input_file, output_file)
+    result = get_mismatched_audio_stream_indices(input_file, output_file)
+    assert result == [1]
 
-    assert "Audio stream MD5 mismatch!" in str(excinfo.value)
+
+@pytest.mark.unit
+def test_get_mismatched_audio_stream_indices_hash_failure(
+    mocker: MockerFixture,
+) -> None:
+    """Tests that indices with hash generation failures are reported."""
+    input_file = Path("dummy_input.ts")
+    output_file = Path("dummy_output.mp4.part")
+
+    mocker.patch("ts2mp4.audio_integrity._get_audio_stream_count", return_value=4)
+    mocker.patch(
+        "ts2mp4.audio_integrity.get_stream_md5",
+        side_effect=[
+            "hash1_input",
+            "hash1_input",  # Match
+            "hash2_input",
+            RuntimeError("ffmpeg error"),  # Output hash fails
+            RuntimeError("ffmpeg error"),  # Input hash fails
+            "hash3_output",
+            "hash4_input",
+            "hash4_output",  # Mismatch
+        ],
+    )
+
+    result = get_mismatched_audio_stream_indices(input_file, output_file)
+    assert result == [1, 2, 3]
 
 
 @pytest.mark.unit
@@ -68,15 +100,15 @@ def test_get_audio_stream_count_failure(mocker: MockerFixture, ts_file: Path) ->
 
 
 @pytest.mark.unit
-def test_verify_audio_stream_integrity_no_audio_streams(
+def test_get_mismatched_audio_stream_indices_no_audio_streams(
     mocker: MockerFixture,
 ) -> None:
+    """Tests correct handling when there are no audio streams."""
     input_file = Path("dummy_input_no_audio.ts")
     output_file = Path("dummy_output_no_audio.mp4.part")
 
     mocker.patch("ts2mp4.audio_integrity._get_audio_stream_count", return_value=0)
-    mocker.patch(
-        "ts2mp4.audio_integrity.get_stream_md5", return_value=""
-    )  # 呼ばれないが念のため
+    mocker.patch("ts2mp4.audio_integrity.get_stream_md5", return_value="")
 
-    verify_audio_stream_integrity(input_file, output_file)
+    result = get_mismatched_audio_stream_indices(input_file, output_file)
+    assert result == []

--- a/tests/test_ts2mp4.py
+++ b/tests/test_ts2mp4.py
@@ -17,7 +17,7 @@ def test_calls_execute_ffmpeg_with_correct_args(mocker: MockerFixture) -> None:
 
     mock_execute_ffmpeg = mocker.patch("ts2mp4.ts2mp4.execute_ffmpeg")
     mock_execute_ffmpeg.return_value = FFmpegResult(stdout=b"", stderr="", returncode=0)
-    mocker.patch("ts2mp4.ts2mp4.verify_audio_stream_integrity")
+    mocker.patch("ts2mp4.ts2mp4.get_mismatched_audio_stream_indices", return_value=[])
 
     # Act
     ts2mp4(input_file, output_file, crf, preset)
@@ -61,7 +61,9 @@ def test_calls_execute_ffmpeg_with_correct_args(mocker: MockerFixture) -> None:
 
 
 @pytest.mark.unit
-def test_calls_verify_audio_stream_integrity_on_success(mocker: MockerFixture) -> None:
+def test_calls_get_mismatched_audio_stream_indices_on_success(
+    mocker: MockerFixture,
+) -> None:
     # Arrange
     input_file = Path("input.ts")
     output_file = Path("output.mp4")
@@ -70,28 +72,28 @@ def test_calls_verify_audio_stream_integrity_on_success(mocker: MockerFixture) -
 
     mock_execute_ffmpeg = mocker.patch("ts2mp4.ts2mp4.execute_ffmpeg")
     mock_execute_ffmpeg.return_value = FFmpegResult(stdout=b"", stderr="", returncode=0)
-    mock_verify_audio_stream_integrity = mocker.patch(
-        "ts2mp4.ts2mp4.verify_audio_stream_integrity"
+    mock_get_mismatched_indices = mocker.patch(
+        "ts2mp4.ts2mp4.get_mismatched_audio_stream_indices", return_value=[]
     )
 
     # Act
     ts2mp4(input_file, output_file, crf, preset)
 
     # Assert
-    mock_verify_audio_stream_integrity.assert_called_once_with(
+    mock_get_mismatched_indices.assert_called_once_with(
         input_file=input_file, output_file=output_file
     )
 
 
 @pytest.mark.unit
-def test_ts2mp4_raises_runtime_error_on_failure(mocker: MockerFixture) -> None:
+def test_ts2mp4_raises_runtime_error_on_ffmpeg_failure(mocker: MockerFixture) -> None:
     # Arrange
     input_file = Path("input.ts")
     output_file = Path("output.mp4")
     crf = 23
     preset = "medium"
 
-    mocker.patch("ts2mp4.ts2mp4.verify_audio_stream_integrity")
+    mocker.patch("ts2mp4.ts2mp4.get_mismatched_audio_stream_indices")
     mock_execute_ffmpeg = mocker.patch("ts2mp4.ts2mp4.execute_ffmpeg")
     mock_execute_ffmpeg.return_value = FFmpegResult(
         stdout=b"", stderr="ffmpeg error", returncode=1
@@ -103,7 +105,7 @@ def test_ts2mp4_raises_runtime_error_on_failure(mocker: MockerFixture) -> None:
 
 
 @pytest.mark.unit
-def test_does_not_call_verify_audio_stream_integrity_on_failure(
+def test_does_not_call_get_mismatched_indices_on_ffmpeg_failure(
     mocker: MockerFixture,
 ) -> None:
     # Arrange
@@ -113,8 +115,8 @@ def test_does_not_call_verify_audio_stream_integrity_on_failure(
     preset = "medium"
 
     mock_execute_ffmpeg = mocker.patch("ts2mp4.ts2mp4.execute_ffmpeg")
-    mock_verify_audio_stream_integrity = mocker.patch(
-        "ts2mp4.ts2mp4.verify_audio_stream_integrity"
+    mock_get_mismatched_indices = mocker.patch(
+        "ts2mp4.ts2mp4.get_mismatched_audio_stream_indices"
     )
     mock_execute_ffmpeg.return_value = FFmpegResult(
         stdout=b"", stderr="ffmpeg error", returncode=1
@@ -124,4 +126,28 @@ def test_does_not_call_verify_audio_stream_integrity_on_failure(
     with pytest.raises(RuntimeError):
         ts2mp4(input_file, output_file, crf, preset)
 
-    mock_verify_audio_stream_integrity.assert_not_called()
+    mock_get_mismatched_indices.assert_not_called()
+
+
+@pytest.mark.unit
+def test_ts2mp4_raises_runtime_error_on_audio_integrity_failure(
+    mocker: MockerFixture,
+) -> None:
+    # Arrange
+    input_file = Path("input.ts")
+    output_file = Path("output.mp4")
+    crf = 23
+    preset = "medium"
+
+    mock_execute_ffmpeg = mocker.patch("ts2mp4.ts2mp4.execute_ffmpeg")
+    mock_execute_ffmpeg.return_value = FFmpegResult(stdout=b"", stderr="", returncode=0)
+    mocker.patch(
+        "ts2mp4.ts2mp4.get_mismatched_audio_stream_indices", return_value=[0, 2]
+    )
+
+    # Act & Assert
+    with pytest.raises(
+        RuntimeError,
+        match="Audio stream integrity check failed for indices: \\[0, 2\\]",
+    ):
+        ts2mp4(input_file, output_file, crf, preset)

--- a/ts2mp4/audio_integrity.py
+++ b/ts2mp4/audio_integrity.py
@@ -19,15 +19,23 @@ def _get_audio_stream_count(file_path: Path) -> int:
     return sum(1 for stream in media_info.streams if stream.codec_type == "audio")
 
 
-def verify_audio_stream_integrity(input_file: Path, output_file: Path) -> None:
-    """Verifies the integrity of audio streams by comparing MD5 hashes before and after conversion.
+def get_mismatched_audio_stream_indices(
+    input_file: Path, output_file: Path
+) -> list[int]:
+    """
+    Verifies audio stream integrity by comparing MD5 hashes, returning problematic indices.
+
+    This function compares the MD5 hashes of audio streams between an input and output file.
+    It identifies streams where the hashes do not match or where hash generation fails for
+    either the input or output stream.
 
     Args:
-        input_file: The path to the original input file.
-        output_file: The path to the converted output file.
+        input_file: Path to the original input file.
+        output_file: Path to the converted output file.
 
-    Raises:
-        RuntimeError: If audio stream MD5 hashes do not match.
+    Returns:
+        A list of integer indices for audio streams that have mismatched or failed MD5 hashes.
+        An empty list is returned if all audio streams are verified successfully.
     """
     logger.info(
         f"Verifying audio stream integrity for {input_file.name} and {output_file.name}"
@@ -35,16 +43,30 @@ def verify_audio_stream_integrity(input_file: Path, output_file: Path) -> None:
     audio_stream_count = _get_audio_stream_count(input_file)
     logger.info(f"Detected {audio_stream_count} audio streams in input file.")
 
-    input_audio_md5s = [
-        get_stream_md5(input_file, "audio", i) for i in range(audio_stream_count)
-    ]
-    output_audio_md5s = [
-        get_stream_md5(output_file, "audio", i) for i in range(audio_stream_count)
-    ]
+    mismatched_indices = []
+    for i in range(audio_stream_count):
+        try:
+            input_md5 = get_stream_md5(input_file, "audio", i)
+            output_md5 = get_stream_md5(output_file, "audio", i)
 
-    if input_audio_md5s != output_audio_md5s:
-        raise RuntimeError(
-            f"Audio stream MD5 mismatch! Input: {input_audio_md5s}, Output: {output_audio_md5s}"
+            if input_md5 != output_md5:
+                logger.warning(
+                    f"Mismatch in audio stream {i}: "
+                    f"Input MD5: {input_md5}, Output MD5: {output_md5}"
+                )
+                mismatched_indices.append(i)
+        except RuntimeError as e:
+            logger.warning(f"Failed to get MD5 for audio stream {i}: {e}")
+            mismatched_indices.append(i)
+
+    if not mismatched_indices:
+        logger.info(
+            "Audio stream integrity verified successfully. All MD5 hashes match."
         )
     else:
-        logger.info("Audio stream integrity verified successfully. MD5 hashes match.")
+        logger.error(
+            f"Found {len(mismatched_indices)} mismatched audio streams at "
+            f"indices: {mismatched_indices}"
+        )
+
+    return mismatched_indices

--- a/ts2mp4/ts2mp4.py
+++ b/ts2mp4/ts2mp4.py
@@ -1,6 +1,6 @@
 from pathlib import Path
 
-from .audio_integrity import verify_audio_stream_integrity
+from .audio_integrity import get_mismatched_audio_stream_indices
 from .ffmpeg import execute_ffmpeg
 
 
@@ -57,4 +57,10 @@ def ts2mp4(input_file: Path, output_file: Path, crf: int, preset: str) -> None:
     if result.returncode != 0:
         raise RuntimeError(f"ffmpeg failed with return code {result.returncode}")
 
-    verify_audio_stream_integrity(input_file=input_file, output_file=output_file)
+    mismatched_indices = get_mismatched_audio_stream_indices(
+        input_file=input_file, output_file=output_file
+    )
+    if mismatched_indices:
+        raise RuntimeError(
+            f"Audio stream integrity check failed for indices: {mismatched_indices}"
+        )


### PR DESCRIPTION
Refactored the audio stream integrity verification logic to enhance error handling and provide more detailed feedback.

- Renamed `verify_audio_stream_integrity` to `get_mismatched_audio_stream_indices` in `ts2mp4/audio_integrity.py`.
- The new function now returns a list of indices for audio streams with mismatched or failed MD5 hashes, instead of raising a `RuntimeError` directly. This allows the caller to decide how to handle the mismatches.
- Updated `ts2mp4/ts2mp4.py` to call the new function and raise a `RuntimeError` if any mismatched indices are found, ensuring existing error flow is maintained while providing a clearer separation of concerns.
- Added comprehensive test cases in `tests/test_audio_integrity.py` to cover scenarios with hash failures and multiple mismatches, ensuring robustness of the new logic.
