### PR TITLE
feat: Switch to ruff for formatting and linting

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,3 +1,0 @@
-[flake8]
-extend-ignore = E501,W503
-exclude = .venv,.svn,CVS,.bzr,.hg,.git,__pycache__,.tox,.nox,.eggs,*.egg

--- a/Makefile
+++ b/Makefile
@@ -2,9 +2,8 @@ TEST_ASSETS_DIR = tests/assets
 
 .PHONY: check
 check: $(TEST_ASSETS_DIR)/test_video.ts
-	poetry run black --check .
-	poetry run isort --check .
-	poetry run flake8 .
+	poetry run ruff check .
+	poetry run ruff format --check .
 	poetry run mypy .
 	@echo "Running unit tests..."
 	poetry run pytest -m unit
@@ -15,8 +14,8 @@ check: $(TEST_ASSETS_DIR)/test_video.ts
 
 .PHONY: format
 format:
-	poetry run isort .
-	poetry run black .
+	poetry run ruff check . --fix
+	poetry run ruff format .
 
 $(TEST_ASSETS_DIR)/test_video.ts: Makefile
 	@mkdir -p $(TEST_ASSETS_DIR)

--- a/poetry.lock
+++ b/poetry.lock
@@ -13,59 +13,12 @@ files = [
 ]
 
 [[package]]
-name = "black"
-version = "25.1.0"
-description = "The uncompromising code formatter."
-optional = false
-python-versions = ">=3.9"
-groups = ["dev"]
-files = [
-    {file = "black-25.1.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:759e7ec1e050a15f89b770cefbf91ebee8917aac5c20483bc2d80a6c3a04df32"},
-    {file = "black-25.1.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:0e519ecf93120f34243e6b0054db49c00a35f84f195d5bce7e9f5cfc578fc2da"},
-    {file = "black-25.1.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:055e59b198df7ac0b7efca5ad7ff2516bca343276c466be72eb04a3bcc1f82d7"},
-    {file = "black-25.1.0-cp310-cp310-win_amd64.whl", hash = "sha256:db8ea9917d6f8fc62abd90d944920d95e73c83a5ee3383493e35d271aca872e9"},
-    {file = "black-25.1.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:a39337598244de4bae26475f77dda852ea00a93bd4c728e09eacd827ec929df0"},
-    {file = "black-25.1.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:96c1c7cd856bba8e20094e36e0f948718dc688dba4a9d78c3adde52b9e6c2299"},
-    {file = "black-25.1.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:bce2e264d59c91e52d8000d507eb20a9aca4a778731a08cfff7e5ac4a4bb7096"},
-    {file = "black-25.1.0-cp311-cp311-win_amd64.whl", hash = "sha256:172b1dbff09f86ce6f4eb8edf9dede08b1fce58ba194c87d7a4f1a5aa2f5b3c2"},
-    {file = "black-25.1.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:4b60580e829091e6f9238c848ea6750efed72140b91b048770b64e74fe04908b"},
-    {file = "black-25.1.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:1e2978f6df243b155ef5fa7e558a43037c3079093ed5d10fd84c43900f2d8ecc"},
-    {file = "black-25.1.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:3b48735872ec535027d979e8dcb20bf4f70b5ac75a8ea99f127c106a7d7aba9f"},
-    {file = "black-25.1.0-cp312-cp312-win_amd64.whl", hash = "sha256:ea0213189960bda9cf99be5b8c8ce66bb054af5e9e861249cd23471bd7b0b3ba"},
-    {file = "black-25.1.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:8f0b18a02996a836cc9c9c78e5babec10930862827b1b724ddfe98ccf2f2fe4f"},
-    {file = "black-25.1.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:afebb7098bfbc70037a053b91ae8437c3857482d3a690fefc03e9ff7aa9a5fd3"},
-    {file = "black-25.1.0-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:030b9759066a4ee5e5aca28c3c77f9c64789cdd4de8ac1df642c40b708be6171"},
-    {file = "black-25.1.0-cp313-cp313-win_amd64.whl", hash = "sha256:a22f402b410566e2d1c950708c77ebf5ebd5d0d88a6a2e87c86d9fb48afa0d18"},
-    {file = "black-25.1.0-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:a1ee0a0c330f7b5130ce0caed9936a904793576ef4d2b98c40835d6a65afa6a0"},
-    {file = "black-25.1.0-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:f3df5f1bf91d36002b0a75389ca8663510cf0531cca8aa5c1ef695b46d98655f"},
-    {file = "black-25.1.0-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:d9e6827d563a2c820772b32ce8a42828dc6790f095f441beef18f96aa6f8294e"},
-    {file = "black-25.1.0-cp39-cp39-win_amd64.whl", hash = "sha256:bacabb307dca5ebaf9c118d2d2f6903da0d62c9faa82bd21a33eecc319559355"},
-    {file = "black-25.1.0-py3-none-any.whl", hash = "sha256:95e8176dae143ba9097f351d174fdaf0ccd29efb414b362ae3fd72bf0f710717"},
-    {file = "black-25.1.0.tar.gz", hash = "sha256:33496d5cd1222ad73391352b4ae8da15253c5de89b93a80b3e2c8d9a19ec2666"},
-]
-
-[package.dependencies]
-click = ">=8.0.0"
-mypy-extensions = ">=0.4.3"
-packaging = ">=22.0"
-pathspec = ">=0.9.0"
-platformdirs = ">=2"
-tomli = {version = ">=1.1.0", markers = "python_version < \"3.11\""}
-typing-extensions = {version = ">=4.0.1", markers = "python_version < \"3.11\""}
-
-[package.extras]
-colorama = ["colorama (>=0.4.3)"]
-d = ["aiohttp (>=3.10)"]
-jupyter = ["ipython (>=7.8.0)", "tokenize-rt (>=3.2.0)"]
-uvloop = ["uvloop (>=0.15.2)"]
-
-[[package]]
 name = "click"
 version = "8.1.8"
 description = "Composable command line interface toolkit"
 optional = false
 python-versions = ">=3.7"
-groups = ["main", "dev"]
+groups = ["main"]
 files = [
     {file = "click-8.1.8-py3-none-any.whl", hash = "sha256:63c132bbbed01578a06712a2d1f497bb62d9c1c0d329b7903a866228027263b2"},
     {file = "click-8.1.8.tar.gz", hash = "sha256:ed53c9d8990d83c2a27deae68e4ee337473f6330c040a31d4225c9574d16096a"},
@@ -85,7 +38,7 @@ files = [
     {file = "colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6"},
     {file = "colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44"},
 ]
-markers = {main = "sys_platform == \"win32\" or platform_system == \"Windows\"", dev = "platform_system == \"Windows\" or sys_platform == \"win32\""}
+markers = {main = "sys_platform == \"win32\" or platform_system == \"Windows\"", dev = "sys_platform == \"win32\""}
 
 [[package]]
 name = "exceptiongroup"
@@ -105,23 +58,6 @@ typing-extensions = {version = ">=4.6.0", markers = "python_version < \"3.13\""}
 
 [package.extras]
 test = ["pytest (>=6)"]
-
-[[package]]
-name = "flake8"
-version = "7.3.0"
-description = "the modular source code checker: pep8 pyflakes and co"
-optional = false
-python-versions = ">=3.9"
-groups = ["dev"]
-files = [
-    {file = "flake8-7.3.0-py2.py3-none-any.whl", hash = "sha256:b9696257b9ce8beb888cdbe31cf885c90d31928fe202be0889a7cdafad32f01e"},
-    {file = "flake8-7.3.0.tar.gz", hash = "sha256:fe044858146b9fc69b551a4b490d69cf960fcb78ad1edcb84e7fbb1b4a8e3872"},
-]
-
-[package.dependencies]
-mccabe = ">=0.7.0,<0.8.0"
-pycodestyle = ">=2.14.0,<2.15.0"
-pyflakes = ">=3.4.0,<3.5.0"
 
 [[package]]
 name = "freezegun"
@@ -149,22 +85,6 @@ files = [
     {file = "iniconfig-2.1.0-py3-none-any.whl", hash = "sha256:9deba5723312380e77435581c6bf4935c94cbfab9b1ed33ef8d238ea168eb760"},
     {file = "iniconfig-2.1.0.tar.gz", hash = "sha256:3abbd2e30b36733fee78f9c7f7308f2d0050e88f0087fd25c2645f63c773e1c7"},
 ]
-
-[[package]]
-name = "isort"
-version = "6.0.1"
-description = "A Python utility / library to sort Python imports."
-optional = false
-python-versions = ">=3.9.0"
-groups = ["dev"]
-files = [
-    {file = "isort-6.0.1-py3-none-any.whl", hash = "sha256:2dc5d7f65c9678d94c88dfc29161a320eec67328bc97aad576874cb4be1e9615"},
-    {file = "isort-6.0.1.tar.gz", hash = "sha256:1cb5df28dfbc742e490c5e41bad6da41b805b0a8be7bc93cd0fb2a8a890ac450"},
-]
-
-[package.extras]
-colors = ["colorama"]
-plugins = ["setuptools"]
 
 [[package]]
 name = "logzero"
@@ -205,18 +125,6 @@ plugins = ["mdit-py-plugins"]
 profiling = ["gprof2dot"]
 rtd = ["jupyter_sphinx", "mdit-py-plugins", "myst-parser", "pyyaml", "sphinx", "sphinx-copybutton", "sphinx-design", "sphinx_book_theme"]
 testing = ["coverage", "pytest", "pytest-cov", "pytest-regressions"]
-
-[[package]]
-name = "mccabe"
-version = "0.7.0"
-description = "McCabe checker, plugin for flake8"
-optional = false
-python-versions = ">=3.6"
-groups = ["dev"]
-files = [
-    {file = "mccabe-0.7.0-py2.py3-none-any.whl", hash = "sha256:6c2d30ab6be0e4a46919781807b4f0d834ebdd6c6e3dca0bda5a15f863427b6e"},
-    {file = "mccabe-0.7.0.tar.gz", hash = "sha256:348e0240c33b60bbdf4e523192ef919f28cb2c3d7d5c7794f74009290f236325"},
-]
 
 [[package]]
 name = "mdurl"
@@ -322,23 +230,6 @@ files = [
 ]
 
 [[package]]
-name = "platformdirs"
-version = "4.3.8"
-description = "A small Python package for determining appropriate platform-specific dirs, e.g. a `user data dir`."
-optional = false
-python-versions = ">=3.9"
-groups = ["dev"]
-files = [
-    {file = "platformdirs-4.3.8-py3-none-any.whl", hash = "sha256:ff7059bb7eb1179e2685604f4aaf157cfd9535242bd23742eadc3c13542139b4"},
-    {file = "platformdirs-4.3.8.tar.gz", hash = "sha256:3d512d96e16bcb959a814c9f348431070822a6496326a4be0911c40b5a74c2bc"},
-]
-
-[package.extras]
-docs = ["furo (>=2024.8.6)", "proselint (>=0.14)", "sphinx (>=8.1.3)", "sphinx-autodoc-typehints (>=3)"]
-test = ["appdirs (==1.4.4)", "covdefaults (>=2.3)", "pytest (>=8.3.4)", "pytest-cov (>=6)", "pytest-mock (>=3.14)"]
-type = ["mypy (>=1.14.1)"]
-
-[[package]]
 name = "pluggy"
 version = "1.6.0"
 description = "plugin and hook calling mechanisms for python"
@@ -353,18 +244,6 @@ files = [
 [package.extras]
 dev = ["pre-commit", "tox"]
 testing = ["coverage", "pytest", "pytest-benchmark"]
-
-[[package]]
-name = "pycodestyle"
-version = "2.14.0"
-description = "Python style guide checker"
-optional = false
-python-versions = ">=3.9"
-groups = ["dev"]
-files = [
-    {file = "pycodestyle-2.14.0-py2.py3-none-any.whl", hash = "sha256:dd6bf7cb4ee77f8e016f9c8e74a35ddd9f67e1d5fd4184d86c3b98e07099f42d"},
-    {file = "pycodestyle-2.14.0.tar.gz", hash = "sha256:c4b5b517d278089ff9d0abdec919cd97262a3367449ea1c8b49b91529167b783"},
-]
 
 [[package]]
 name = "pydantic"
@@ -501,36 +380,6 @@ files = [
 typing-extensions = ">=4.6.0,<4.7.0 || >4.7.0"
 
 [[package]]
-name = "pydocstyle"
-version = "6.3.0"
-description = "Python docstring style checker"
-optional = false
-python-versions = ">=3.6"
-groups = ["dev"]
-files = [
-    {file = "pydocstyle-6.3.0-py3-none-any.whl", hash = "sha256:118762d452a49d6b05e194ef344a55822987a462831ade91ec5c06fd2169d019"},
-    {file = "pydocstyle-6.3.0.tar.gz", hash = "sha256:7ce43f0c0ac87b07494eb9c0b462c0b73e6ff276807f204d6b53edc72b7e44e1"},
-]
-
-[package.dependencies]
-snowballstemmer = ">=2.2.0"
-
-[package.extras]
-toml = ["tomli (>=1.2.3) ; python_version < \"3.11\""]
-
-[[package]]
-name = "pyflakes"
-version = "3.4.0"
-description = "passive checker of Python programs"
-optional = false
-python-versions = ">=3.9"
-groups = ["dev"]
-files = [
-    {file = "pyflakes-3.4.0-py2.py3-none-any.whl", hash = "sha256:f742a7dbd0d9cb9ea41e9a24a918996e8170c799fa528688d40dd582c8265f4f"},
-    {file = "pyflakes-3.4.0.tar.gz", hash = "sha256:b24f96fafb7d2ab0ec5075b7350b3d2d2218eab42003821c06344973d3ea2f58"},
-]
-
-[[package]]
 name = "pygments"
 version = "2.19.2"
 description = "Pygments is a syntax highlighting package written in Python."
@@ -623,6 +472,34 @@ typing-extensions = {version = ">=4.0.0,<5.0", markers = "python_version < \"3.1
 jupyter = ["ipywidgets (>=7.5.1,<9)"]
 
 [[package]]
+name = "ruff"
+version = "0.5.7"
+description = "An extremely fast Python linter and code formatter, written in Rust."
+optional = false
+python-versions = ">=3.7"
+groups = ["dev"]
+files = [
+    {file = "ruff-0.5.7-py3-none-linux_armv6l.whl", hash = "sha256:548992d342fc404ee2e15a242cdbea4f8e39a52f2e7752d0e4cbe88d2d2f416a"},
+    {file = "ruff-0.5.7-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:00cc8872331055ee017c4f1071a8a31ca0809ccc0657da1d154a1d2abac5c0be"},
+    {file = "ruff-0.5.7-py3-none-macosx_11_0_arm64.whl", hash = "sha256:eaf3d86a1fdac1aec8a3417a63587d93f906c678bb9ed0b796da7b59c1114a1e"},
+    {file = "ruff-0.5.7-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a01c34400097b06cf8a6e61b35d6d456d5bd1ae6961542de18ec81eaf33b4cb8"},
+    {file = "ruff-0.5.7-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:fcc8054f1a717e2213500edaddcf1dbb0abad40d98e1bd9d0ad364f75c763eea"},
+    {file = "ruff-0.5.7-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:7f70284e73f36558ef51602254451e50dd6cc479f8b6f8413a95fcb5db4a55fc"},
+    {file = "ruff-0.5.7-py3-none-manylinux_2_17_ppc64.manylinux2014_ppc64.whl", hash = "sha256:a78ad870ae3c460394fc95437d43deb5c04b5c29297815a2a1de028903f19692"},
+    {file = "ruff-0.5.7-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:9ccd078c66a8e419475174bfe60a69adb36ce04f8d4e91b006f1329d5cd44bcf"},
+    {file = "ruff-0.5.7-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:7e31c9bad4ebf8fdb77b59cae75814440731060a09a0e0077d559a556453acbb"},
+    {file = "ruff-0.5.7-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:8d796327eed8e168164346b769dd9a27a70e0298d667b4ecee6877ce8095ec8e"},
+    {file = "ruff-0.5.7-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:4a09ea2c3f7778cc635e7f6edf57d566a8ee8f485f3c4454db7771efb692c499"},
+    {file = "ruff-0.5.7-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:a36d8dcf55b3a3bc353270d544fb170d75d2dff41eba5df57b4e0b67a95bb64e"},
+    {file = "ruff-0.5.7-py3-none-musllinux_1_2_i686.whl", hash = "sha256:9369c218f789eefbd1b8d82a8cf25017b523ac47d96b2f531eba73770971c9e5"},
+    {file = "ruff-0.5.7-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:b88ca3db7eb377eb24fb7c82840546fb7acef75af4a74bd36e9ceb37a890257e"},
+    {file = "ruff-0.5.7-py3-none-win32.whl", hash = "sha256:33d61fc0e902198a3e55719f4be6b375b28f860b09c281e4bdbf783c0566576a"},
+    {file = "ruff-0.5.7-py3-none-win_amd64.whl", hash = "sha256:083bbcbe6fadb93cd86709037acc510f86eed5a314203079df174c40bbbca6b3"},
+    {file = "ruff-0.5.7-py3-none-win_arm64.whl", hash = "sha256:2dca26154ff9571995107221d0aeaad0e75a77b5a682d6236cf89a58c70b76f4"},
+    {file = "ruff-0.5.7.tar.gz", hash = "sha256:8dfc0a458797f5d9fb622dd0efc52d796f23f0a1493a9527f4e49a550ae9a7e5"},
+]
+
+[[package]]
 name = "shellingham"
 version = "1.5.4"
 description = "Tool to Detect Surrounding Shell"
@@ -644,18 +521,6 @@ groups = ["dev"]
 files = [
     {file = "six-1.17.0-py2.py3-none-any.whl", hash = "sha256:4721f391ed90541fddacab5acf947aa0d3dc7d27b2e1e8eda2be8970586c3274"},
     {file = "six-1.17.0.tar.gz", hash = "sha256:ff70335d468e7eb6ec65b95b99d3a2836546063f63acc5171de367e834932a81"},
-]
-
-[[package]]
-name = "snowballstemmer"
-version = "3.0.1"
-description = "This package provides 32 stemmers for 30 languages generated from Snowball algorithms."
-optional = false
-python-versions = "!=3.0.*,!=3.1.*,!=3.2.*"
-groups = ["dev"]
-files = [
-    {file = "snowballstemmer-3.0.1-py3-none-any.whl", hash = "sha256:6cd7b3897da8d6c9ffb968a6781fa6532dce9c3618a4b127d920dab764a19064"},
-    {file = "snowballstemmer-3.0.1.tar.gz", hash = "sha256:6d5eeeec8e9f84d4d56b847692bacf79bc2c8e90c7f80ca4444ff8b6f2e52895"},
 ]
 
 [[package]]
@@ -749,4 +614,4 @@ typing-extensions = ">=4.12.0"
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.9"
-content-hash = "d0bb9f94f70ff66bf8f88e3fe60f9f7c55757ec0aea139658a898d34d07b650e"
+content-hash = "998140087c9f6ff6f41b315264a116b586f603d00fb5248053a76a6388960469"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,7 +48,11 @@ select = [
   "W",  # pycodestyle warnings
   "F",  # pyflakes
   "I",  # isort
+  # "D",  # pydocstyle - Temporarily disabled
 ]
+
+[tool.ruff.lint.pydocstyle]
+convention = "numpy"
 
 [build-system]
 requires = ["poetry-core>=1.0.0"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,6 +50,7 @@ select = [
   "I",  # isort
   # "D",  # pydocstyle - Temporarily disabled
 ]
+ignore = ["E501"]
 
 [tool.ruff.lint.pydocstyle]
 convention = "numpy"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,3 @@
-[tool.isort]
-profile = "black"
-
 [tool.mypy]
 strict = true
 exclude = [".venv", "build", "dist"]
@@ -22,14 +19,11 @@ pydantic = "^2.5.3"
 typer = "^0.16.0"
 
 [tool.poetry.group.dev.dependencies]
-black = "^25.1.0"
-flake8 = "^7.3.0"
 freezegun = "^1.5.3"
-isort = "^6.0.1"
 mypy = "^1.4.1"
-pydocstyle = "^6.3.0"
 pytest = "^8.4.1"
 pytest-mock = "^3.14.1"
+ruff = "^0.5.5"
 
 [tool.poetry.scripts]
 ts2mp4 = "ts2mp4.cli:app"
@@ -39,6 +33,21 @@ markers = [
     "unit: mark a test as a unit test.",
     "integration: mark a test as an integration test.",
     "e2e: mark a test as an end-to-end test.",
+]
+
+[tool.ruff]
+line-length = 88
+target-version = "py39"
+
+[tool.ruff.format]
+quote-style = "double"
+
+[tool.ruff.lint]
+select = [
+  "E",  # pycodestyle errors
+  "W",  # pycodestyle warnings
+  "F",  # pyflakes
+  "I",  # isort
 ]
 
 [build-system]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -8,9 +8,7 @@ ALLOWED_MARKERS = {"unit", "integration", "e2e"}
 def pytest_collection_modifyitems(
     session: pytest.Session, items: list[pytest.Item]
 ) -> None:
-    """
-    Validate that every test is marked with exactly one of the allowed markers.
-    """
+    """Validate that every test is marked with exactly one of the allowed markers."""
     sorted_markers = sorted(list(ALLOWED_MARKERS))
 
     for item in items:
@@ -20,12 +18,15 @@ def pytest_collection_modifyitems(
         if len(intersecting_markers) == 0:
             pytest.fail(
                 f"Test item '{item.nodeid}' is missing a required mark. "
-                f"Please add one of: @pytest.mark.{', @pytest.mark.'.join(sorted_markers)}"
+                "Please add one of: "
+                f"@pytest.mark.{', @pytest.mark.'.join(sorted_markers)}"
             )
         elif len(intersecting_markers) > 1:
             pytest.fail(
-                f"Test item '{item.nodeid}' has multiple classification marks: {intersecting_markers}. "
-                f"Please specify exactly one of: @pytest.mark.{', @pytest.mark.'.join(sorted_markers)}"
+                f"Test item '{item.nodeid}' has multiple "
+                f"classification marks: {intersecting_markers}. "
+                "Please specify exactly one of: "
+                f"@pytest.mark.{', @pytest.mark.'.join(sorted_markers)}"
             )
 
 

--- a/tests/test_audio_integrity.py
+++ b/tests/test_audio_integrity.py
@@ -19,6 +19,7 @@ def test_get_audio_stream_count(ts_file: Path) -> None:
 
 @pytest.mark.unit
 def test_verify_audio_stream_integrity_matches(mocker: MockerFixture) -> None:
+    """Test that verify_audio_stream_integrity passes when MD5s match."""
     input_file = Path("dummy_input.ts")
     output_file = Path("dummy_output.mp4.part")
 
@@ -38,6 +39,7 @@ def test_verify_audio_stream_integrity_matches(mocker: MockerFixture) -> None:
 
 @pytest.mark.unit
 def test_verify_audio_stream_integrity_mismatch(mocker: MockerFixture) -> None:
+    """Test that verify_audio_stream_integrity raises RuntimeError on MD5 mismatch."""
     input_file = Path("dummy_input.ts")
     output_file = Path("dummy_output.mp4.part")
 
@@ -71,6 +73,7 @@ def test_get_audio_stream_count_failure(mocker: MockerFixture, ts_file: Path) ->
 def test_verify_audio_stream_integrity_no_audio_streams(
     mocker: MockerFixture,
 ) -> None:
+    """Test that verify_audio_stream_integrity passes with no audio streams."""
     input_file = Path("dummy_input_no_audio.ts")
     output_file = Path("dummy_output_no_audio.mp4.part")
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -18,7 +18,8 @@ def test_cli_entry_points_start_correctly(command: list[str]) -> None:
     """Test that CLI entry points run without error and show help message."""
     result = subprocess.run(command, capture_output=True, text=True, check=True)
 
-    # Check that the output contains the usage string to ensure the Typer CLI is running.
+    # Check that the output contains the usage string to ensure the Typer CLI is
+    # running.
     assert "Usage:" in result.stdout
 
 

--- a/tests/test_e2e.py
+++ b/tests/test_e2e.py
@@ -7,7 +7,7 @@ import pytest
 
 @pytest.fixture(autouse=True)
 def cleanup_files(mp4_file: Path) -> Generator[None, None, None]:
-    """Ensures the .mp4 and .log files are removed before and after each test."""
+    """Ensure the .mp4 and .log files are removed before and after each test."""
 
     def _cleanup() -> None:
         mp4_file.unlink(missing_ok=True)

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -8,12 +8,14 @@ from ts2mp4 import _get_ts2mp4_version
 
 @pytest.mark.unit
 def test_get_ts2mp4_version_success(mocker: MockerFixture) -> None:
+    """Test that _get_ts2mp4_version returns the version on success."""
     mocker.patch("importlib.metadata.version", return_value="1.2.3")
     assert _get_ts2mp4_version() == "1.2.3"
 
 
 @pytest.mark.unit
 def test_get_ts2mp4_version_package_not_found(mocker: MockerFixture) -> None:
+    """Test that _get_ts2mp4_version returns 'unknown' on PackageNotFoundError."""
     mocker.patch(
         "importlib.metadata.version",
         side_effect=importlib.metadata.PackageNotFoundError,

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -7,7 +7,6 @@ import pytest
 @pytest.mark.e2e
 def test_log_file_creation_and_content(tmp_path: Path, project_root: Path) -> None:
     """Test that a log file is created and contains expected messages."""
-
     # Define paths directly using tmp_path
     temp_ts_file = tmp_path / "dummy.ts"
     temp_log_file = tmp_path / "conversion.log"

--- a/tests/test_media_info.py
+++ b/tests/test_media_info.py
@@ -15,6 +15,7 @@ def _clear_cache() -> None:
 
 @pytest.mark.unit
 def test_get_media_info_success(mocker: MockerFixture) -> None:
+    """Test that get_media_info returns a MediaInfo object on success."""
     # Arrange
     mock_execute_ffprobe = mocker.patch("ts2mp4.media_info.execute_ffprobe")
     file_path = Path("test.ts")
@@ -44,6 +45,7 @@ def test_get_media_info_success(mocker: MockerFixture) -> None:
 
 @pytest.mark.unit
 def test_get_media_info_failure(mocker: MockerFixture) -> None:
+    """Test that get_media_info raises a RuntimeError on ffprobe failure."""
     # Arrange
     mock_execute_ffprobe = mocker.patch("ts2mp4.media_info.execute_ffprobe")
     file_path = Path("test.ts")
@@ -58,6 +60,7 @@ def test_get_media_info_failure(mocker: MockerFixture) -> None:
 
 @pytest.mark.unit
 def test_get_media_info_invalid_json(mocker: MockerFixture) -> None:
+    """Test that get_media_info raises a RuntimeError on invalid JSON."""
     # Arrange
     mock_execute_ffprobe = mocker.patch("ts2mp4.media_info.execute_ffprobe")
     file_path = Path("test.ts")
@@ -73,6 +76,7 @@ def test_get_media_info_invalid_json(mocker: MockerFixture) -> None:
 
 @pytest.mark.unit
 def test_get_media_info_ignores_unknown_fields(mocker: MockerFixture) -> None:
+    """Test that get_media_info ignores unknown fields in the JSON output."""
     # Arrange
     mock_execute_ffprobe = mocker.patch("ts2mp4.media_info.execute_ffprobe")
     file_path = Path("test.ts")
@@ -101,6 +105,7 @@ def test_get_media_info_ignores_unknown_fields(mocker: MockerFixture) -> None:
 
 @pytest.mark.unit
 def test_get_media_info_cached(mocker: MockerFixture) -> None:
+    """Test that get_media_info caches the result."""
     # Arrange
     mock_execute_ffprobe = mocker.patch("ts2mp4.media_info.execute_ffprobe")
     file_path = Path("test.ts")
@@ -124,6 +129,7 @@ def test_get_media_info_cached(mocker: MockerFixture) -> None:
 
 @pytest.mark.integration
 def test_get_media_info_integration(ts_file: Path) -> None:
+    """Test that get_media_info works with a real ts file."""
     # Act
     result = get_media_info(ts_file)
 

--- a/tests/test_ts2mp4.py
+++ b/tests/test_ts2mp4.py
@@ -9,6 +9,7 @@ from ts2mp4.ts2mp4 import ts2mp4
 
 @pytest.mark.unit
 def test_calls_execute_ffmpeg_with_correct_args(mocker: MockerFixture) -> None:
+    """Test that ts2mp4 calls execute_ffmpeg with the correct arguments."""
     # Arrange
     input_file = Path("input.ts")
     output_file = Path("output.mp4")
@@ -62,6 +63,7 @@ def test_calls_execute_ffmpeg_with_correct_args(mocker: MockerFixture) -> None:
 
 @pytest.mark.unit
 def test_calls_verify_audio_stream_integrity_on_success(mocker: MockerFixture) -> None:
+    """Test that ts2mp4 calls verify_audio_stream_integrity on success."""
     # Arrange
     input_file = Path("input.ts")
     output_file = Path("output.mp4")
@@ -85,6 +87,7 @@ def test_calls_verify_audio_stream_integrity_on_success(mocker: MockerFixture) -
 
 @pytest.mark.unit
 def test_ts2mp4_raises_runtime_error_on_failure(mocker: MockerFixture) -> None:
+    """Test that ts2mp4 raises a RuntimeError on ffmpeg failure."""
     # Arrange
     input_file = Path("input.ts")
     output_file = Path("output.mp4")
@@ -106,6 +109,7 @@ def test_ts2mp4_raises_runtime_error_on_failure(mocker: MockerFixture) -> None:
 def test_does_not_call_verify_audio_stream_integrity_on_failure(
     mocker: MockerFixture,
 ) -> None:
+    """Test that ts2mp4 does not call verify_audio_stream_integrity on failure."""
     # Arrange
     input_file = Path("input.ts")
     output_file = Path("output.mp4")

--- a/ts2mp4/audio_integrity.py
+++ b/ts2mp4/audio_integrity.py
@@ -7,27 +7,33 @@ from .media_info import get_media_info
 
 
 def _get_audio_stream_count(file_path: Path) -> int:
-    """Returns the number of audio streams in a given file.
+    """Return the number of audio streams in a given file.
 
     Args:
+    ----
         file_path: The path to the input file.
 
     Returns:
+    -------
         The number of audio streams.
+
     """
     media_info = get_media_info(file_path)
     return sum(1 for stream in media_info.streams if stream.codec_type == "audio")
 
 
 def verify_audio_stream_integrity(input_file: Path, output_file: Path) -> None:
-    """Verifies the integrity of audio streams by comparing MD5 hashes before and after conversion.
+    """Verify the integrity of audio streams by comparing MD5 hashes.
 
     Args:
+    ----
         input_file: The path to the original input file.
         output_file: The path to the converted output file.
 
     Raises:
+    ------
         RuntimeError: If audio stream MD5 hashes do not match.
+
     """
     logger.info(
         f"Verifying audio stream integrity for {input_file.name} and {output_file.name}"
@@ -44,7 +50,8 @@ def verify_audio_stream_integrity(input_file: Path, output_file: Path) -> None:
 
     if input_audio_md5s != output_audio_md5s:
         raise RuntimeError(
-            f"Audio stream MD5 mismatch! Input: {input_audio_md5s}, Output: {output_audio_md5s}"
+            "Audio stream MD5 mismatch! "
+            f"Input: {input_audio_md5s}, Output: {output_audio_md5s}"
         )
     else:
         logger.info("Audio stream integrity verified successfully. MD5 hashes match.")

--- a/ts2mp4/cli.py
+++ b/ts2mp4/cli.py
@@ -13,6 +13,8 @@ from ts2mp4.ts2mp4 import ts2mp4
 
 
 class Preset(str, Enum):
+    """Enum for FFmpeg presets."""
+
     ultrafast = "ultrafast"
     superfast = "superfast"
     veryfast = "veryfast"
@@ -49,6 +51,7 @@ def main(
         Preset, typer.Option(help="Encoding preset. Defaults to 'slow'.")
     ] = Preset.slow,
 ) -> None:
+    """Convert a Transport Stream (TS) file to MP4 format."""
     if log_file is None:
         timestamp = datetime.datetime.now().strftime("%Y%m%d%H%M%S")
         log_file = path.with_stem(f"{path.stem}-{timestamp}").with_suffix(".log")

--- a/ts2mp4/ffmpeg.py
+++ b/ts2mp4/ffmpeg.py
@@ -5,6 +5,8 @@ from logzero import logger
 
 
 class FFmpegResult(NamedTuple):
+    """A class to hold the results of an FFmpeg command."""
+
     stdout: bytes
     stderr: str
     returncode: int
@@ -30,26 +32,30 @@ def _execute_process(
 
 
 def execute_ffmpeg(args: list[str]) -> FFmpegResult:
-    """
-    Executes ffmpeg and returns the result.
+    """Execute ffmpeg and returns the result.
 
     Args:
+    ----
         args: A list of arguments for the command.
 
     Returns:
+    -------
         An FFmpegResult object with the command's results.
+
     """
     return _execute_process("ffmpeg", args)
 
 
 def execute_ffprobe(args: list[str]) -> FFmpegResult:
-    """
-    Executes ffprobe and returns the result.
+    """Execute ffprobe and returns the result.
 
     Args:
+    ----
         args: A list of arguments for the command.
 
     Returns:
+    -------
         An FFmpegResult object with the command's results.
+
     """
     return _execute_process("ffprobe", args)

--- a/ts2mp4/hashing.py
+++ b/ts2mp4/hashing.py
@@ -8,18 +8,22 @@ StreamType = Literal["audio", "video"]
 
 
 def get_stream_md5(file_path: Path, stream_type: StreamType, stream_index: int) -> str:
-    """Calculates the MD5 hash of a decoded stream of a given file.
+    """Calculate the MD5 hash of a decoded stream of a given file.
 
     Args:
+    ----
         file_path: The path to the input file.
         stream_type: The type of the stream to process ('audio' or 'video').
         stream_index: The index of the stream to process.
 
     Returns:
+    -------
         The MD5 hash of the decoded stream as a hexadecimal string.
 
     Raises:
+    ------
         RuntimeError: If ffmpeg fails to extract the stream.
+
     """
     if stream_type == "audio":
         map_specifier = f"0:a:{stream_index}"

--- a/ts2mp4/media_info.py
+++ b/ts2mp4/media_info.py
@@ -9,12 +9,16 @@ from .ffmpeg import execute_ffprobe
 
 
 class Stream(BaseModel):
+    """A class to hold information about a single stream."""
+
     model_config = ConfigDict(frozen=True)
 
     codec_type: Optional[str] = None
 
 
 class Format(BaseModel):
+    """A class to hold information about the format of a media file."""
+
     model_config = ConfigDict(frozen=True)
 
     format_name: Optional[str] = None
@@ -29,17 +33,20 @@ class MediaInfo(BaseModel):
 
 @cache
 def get_media_info(file_path: Path) -> MediaInfo:
-    """
-    Returns media information for a given file.
+    """Returns media information for a given file.
 
     Args:
+    ----
         file_path: The path to the input file.
 
     Returns:
+    -------
         A MediaInfo object with the media information.
 
     Raises:
+    ------
         RuntimeError: If ffprobe fails to get media information.
+
     """
     ffprobe_args = [
         "-hide_banner",

--- a/ts2mp4/ts2mp4.py
+++ b/ts2mp4/ts2mp4.py
@@ -12,12 +12,14 @@ def ts2mp4(input_file: Path, output_file: Path, crf: int, preset: str) -> None:
     integrity of the converted file.
 
     Args:
+    ----
         input_file: The path to the input TS file.
         output_file: The path where the output MP4 file will be saved.
         crf: The Constant Rate Factor (CRF) value for video encoding. Lower
             values result in higher quality and larger file sizes.
         preset: The encoding preset for FFmpeg. This affects the compression
             speed and efficiency (e.g., 'medium', 'fast', 'slow').
+
     """
     ffmpeg_args = [
         "-hide_banner",


### PR DESCRIPTION
This commit switches the project from black, flake8, and isort to ruff for formatting and linting. The Makefile and pyproject.toml have been updated to use ruff, and the old dependencies have been removed.
