### PR TITLE
feat: Introduce AudioStreamIndex for type safety

### DIFF
--- a/tests/test_audio_integrity.py
+++ b/tests/test_audio_integrity.py
@@ -7,6 +7,7 @@ from ts2mp4.audio_integrity import (
     _get_audio_stream_count,
     get_mismatched_audio_stream_indices,
 )
+from ts2mp4.types import AudioStreamIndex
 
 
 @pytest.mark.integration
@@ -63,7 +64,7 @@ def test_get_mismatched_audio_stream_indices_mismatch(mocker: MockerFixture) -> 
     )
 
     result = get_mismatched_audio_stream_indices(input_file, output_file)
-    assert result == [1]
+    assert result == [AudioStreamIndex(1)]
 
 
 @pytest.mark.unit
@@ -94,7 +95,7 @@ def test_get_mismatched_audio_stream_indices_hash_failure(
     )
 
     result = get_mismatched_audio_stream_indices(input_file, output_file)
-    assert result == [1, 2, 3]
+    assert result == [AudioStreamIndex(1), AudioStreamIndex(2), AudioStreamIndex(3)]
 
 
 @pytest.mark.unit

--- a/tests/test_ts2mp4.py
+++ b/tests/test_ts2mp4.py
@@ -5,6 +5,7 @@ from pytest_mock import MockerFixture
 
 from ts2mp4.ffmpeg import FFmpegResult
 from ts2mp4.ts2mp4 import ts2mp4
+from ts2mp4.types import AudioStreamIndex
 
 
 @pytest.mark.unit
@@ -142,7 +143,8 @@ def test_ts2mp4_raises_runtime_error_on_audio_integrity_failure(
     mock_execute_ffmpeg = mocker.patch("ts2mp4.ts2mp4.execute_ffmpeg")
     mock_execute_ffmpeg.return_value = FFmpegResult(stdout=b"", stderr="", returncode=0)
     mocker.patch(
-        "ts2mp4.ts2mp4.get_mismatched_audio_stream_indices", return_value=[0, 2]
+        "ts2mp4.ts2mp4.get_mismatched_audio_stream_indices",
+        return_value=[AudioStreamIndex(0), AudioStreamIndex(2)],
     )
 
     # Act & Assert

--- a/ts2mp4/audio_integrity.py
+++ b/ts2mp4/audio_integrity.py
@@ -4,6 +4,7 @@ from logzero import logger
 
 from .hashing import get_stream_md5
 from .media_info import get_media_info
+from .types import AudioStreamIndex
 
 
 def _get_audio_stream_count(file_path: Path) -> int:
@@ -21,7 +22,7 @@ def _get_audio_stream_count(file_path: Path) -> int:
 
 def get_mismatched_audio_stream_indices(
     input_file: Path, output_file: Path
-) -> list[int]:
+) -> list[AudioStreamIndex]:
     """
     Verifies audio stream integrity by comparing MD5 hashes, returning problematic indices.
 
@@ -34,7 +35,7 @@ def get_mismatched_audio_stream_indices(
         output_file: Path to the converted output file.
 
     Returns:
-        A list of integer indices for audio streams that have mismatched or failed MD5 hashes.
+        A list of audio stream indices for streams that have mismatched or failed MD5 hashes.
         An empty list is returned if all audio streams are verified successfully.
     """
     logger.info(
@@ -54,10 +55,10 @@ def get_mismatched_audio_stream_indices(
                     f"Mismatch in audio stream {i}: "
                     f"Input MD5: {input_md5}, Output MD5: {output_md5}"
                 )
-                mismatched_indices.append(i)
+                mismatched_indices.append(AudioStreamIndex(i))
         except RuntimeError as e:
             logger.warning(f"Failed to get MD5 for audio stream {i}: {e}")
-            mismatched_indices.append(i)
+            mismatched_indices.append(AudioStreamIndex(i))
 
     if not mismatched_indices:
         logger.info(

--- a/ts2mp4/types.py
+++ b/ts2mp4/types.py
@@ -1,0 +1,3 @@
+from typing import NewType
+
+AudioStreamIndex = NewType("AudioStreamIndex", int)


### PR DESCRIPTION
Introduces a new `AudioStreamIndex` NewType to explicitly represent audio stream indices, enhancing type safety and code clarity.

- Defines `AudioStreamIndex` in `ts2mp4/types.py`.
- Updates `ts2mp4/audio_integrity.py` to use `AudioStreamIndex` for return type hints and when populating lists of mismatched indices.
- Modifies `tests/test_audio_integrity.py` and `tests/test_ts2mp4.py` to align test assertions and mock data with the new `AudioStreamIndex` type.
