### PR TITLE
refactor: Improve audio stream integrity checks and media info handling

### DIFF
--- a/tests/test_audio_integrity.py
+++ b/tests/test_audio_integrity.py
@@ -166,11 +166,11 @@ def test_get_mismatched_audio_stream_indices_no_audio_streams(
             MediaInfo(streams=no_audio_streams),
         ],
     )
-    mocker.patch("ts2mp4.audio_integrity.get_stream_md5")
+    mock_get_stream_md5 = mocker.patch("ts2mp4.audio_integrity.get_stream_md5")
 
     result = get_mismatched_audio_stream_indices(input_file, output_file)
     assert result == []
-    mocker.patch("ts2mp4.audio_integrity.get_stream_md5").assert_not_called()
+    mock_get_stream_md5.assert_not_called()
 
 
 @pytest.mark.unit
@@ -192,11 +192,11 @@ def test_get_mismatched_audio_stream_indices_missing_output_stream(
             MediaInfo(streams=(Stream(codec_type="video", index=0),)),
         ],
     )
-    mocker.patch("ts2mp4.audio_integrity.get_stream_md5")
+    mock_get_stream_md5 = mocker.patch("ts2mp4.audio_integrity.get_stream_md5")
 
     result = get_mismatched_audio_stream_indices(input_file, output_file)
     assert result == [1]
-    mocker.patch("ts2mp4.audio_integrity.get_stream_md5").assert_not_called()
+    mock_get_stream_md5.assert_not_called()
 
 
 @pytest.mark.unit
@@ -223,8 +223,8 @@ def test_get_mismatched_audio_stream_indices_output_stream_type_mismatch(
             ),
         ],
     )
-    mocker.patch("ts2mp4.audio_integrity.get_stream_md5")
+    mock_get_stream_md5 = mocker.patch("ts2mp4.audio_integrity.get_stream_md5")
 
     result = get_mismatched_audio_stream_indices(input_file, output_file)
     assert result == [1]
-    mocker.patch("ts2mp4.audio_integrity.get_stream_md5").assert_not_called()
+    mock_get_stream_md5.assert_not_called()

--- a/tests/test_audio_integrity.py
+++ b/tests/test_audio_integrity.py
@@ -1,21 +1,11 @@
 from pathlib import Path
+from typing import Union
 
 import pytest
 from pytest_mock import MockerFixture
 
-from ts2mp4.audio_integrity import (
-    _get_audio_stream_count,
-    get_mismatched_audio_stream_indices,
-)
-from ts2mp4.types import AudioStreamIndex
-
-
-@pytest.mark.integration
-def test_get_audio_stream_count(ts_file: Path) -> None:
-    """Test the _get_audio_stream_count helper function."""
-    expected_stream_count = 1
-    actual_stream_count = _get_audio_stream_count(ts_file)
-    assert actual_stream_count == expected_stream_count
+from ts2mp4.audio_integrity import get_mismatched_audio_stream_indices
+from ts2mp4.media_info import MediaInfo, Stream
 
 
 @pytest.mark.unit
@@ -24,16 +14,27 @@ def test_get_mismatched_audio_stream_indices_matches(mocker: MockerFixture) -> N
     input_file = Path("dummy_input.ts")
     output_file = Path("dummy_output.mp4.part")
 
-    mocker.patch("ts2mp4.audio_integrity._get_audio_stream_count", return_value=2)
+    common_streams = (
+        Stream(codec_type="video", index=0),
+        Stream(codec_type="audio", index=1),
+        Stream(codec_type="audio", index=2),
+    )
+
+    mocker.patch(
+        "ts2mp4.audio_integrity.get_media_info",
+        side_effect=[
+            MediaInfo(streams=common_streams),  # MediaInfo for input_file
+            MediaInfo(streams=common_streams),  # MediaInfo for output_file
+        ],
+    )
+
     mocker.patch(
         "ts2mp4.audio_integrity.get_stream_md5",
         side_effect=[
-            # Stream 0: Match
-            "stream_0_hash",
-            "stream_0_hash",
-            # Stream 1: Match
-            "stream_1_hash",
-            "stream_1_hash",
+            "stream_1_hash",  # For input_file, stream_index=1
+            "stream_1_hash",  # For output_file, stream_index=1
+            "stream_2_hash",  # For input_file, stream_index=2
+            "stream_2_hash",  # For output_file, stream_index=2
         ],
     )
 
@@ -47,66 +48,102 @@ def test_get_mismatched_audio_stream_indices_mismatch(mocker: MockerFixture) -> 
     input_file = Path("dummy_input.ts")
     output_file = Path("dummy_output.mp4.part")
 
-    mocker.patch("ts2mp4.audio_integrity._get_audio_stream_count", return_value=3)
+    common_streams = (
+        Stream(codec_type="video", index=0),
+        Stream(codec_type="audio", index=1),
+        Stream(codec_type="audio", index=2),
+    )
+
+    mocker.patch(
+        "ts2mp4.audio_integrity.get_media_info",
+        side_effect=[
+            MediaInfo(streams=common_streams),  # MediaInfo for input_file
+            MediaInfo(streams=common_streams),  # MediaInfo for output_file
+        ],
+    )
+
     mocker.patch(
         "ts2mp4.audio_integrity.get_stream_md5",
         side_effect=[
-            # Stream 0: Match
-            "stream_0_hash",
-            "stream_0_hash",
-            # Stream 1: Mismatch
-            "stream_1_input_hash",
-            "stream_1_output_hash_mismatch",
-            # Stream 2: Match
-            "stream_2_hash",
-            "stream_2_hash",
+            "stream_1_input_hash",  # For input_file, stream_index=1
+            "stream_1_output_hash_mismatch",  # For output_file, stream_index=1
+            "stream_2_hash",  # For input_file, stream_index=2
+            "stream_2_hash",  # For output_file, stream_index=2
         ],
     )
 
     result = get_mismatched_audio_stream_indices(input_file, output_file)
-    assert result == [AudioStreamIndex(1)]
+    assert result == [1]  # Index of the mismatched audio stream
 
 
 @pytest.mark.unit
+@pytest.mark.parametrize(
+    "md5_side_effect, expected_result",
+    [
+        pytest.param(
+            [
+                "stream_1_input_hash",
+                RuntimeError("ffmpeg error: stream 1 output hash failed"),
+                "stream_2_hash",
+                "stream_2_hash",
+                "stream_3_hash",
+                "stream_3_hash",
+            ],
+            [1],
+            id="output_hash_failure",
+        ),
+        pytest.param(
+            [
+                "stream_1_hash",
+                "stream_1_hash",
+                RuntimeError("ffmpeg error: stream 2 input hash failed"),
+                "stream_3_hash",
+                "stream_3_hash",
+            ],
+            [2],
+            id="input_hash_failure",
+        ),
+        pytest.param(
+            [
+                "stream_1_input_ok",
+                RuntimeError("ffmpeg error: stream 1 output failed"),
+                RuntimeError("ffmpeg error: stream 2 input failed"),
+                "stream_3_input_ok",
+                RuntimeError("ffmpeg error: stream 3 output failed"),
+            ],
+            [1, 2, 3],
+            id="multiple_hash_failures",
+        ),
+    ],
+)
 def test_get_mismatched_audio_stream_indices_hash_failure(
     mocker: MockerFixture,
+    md5_side_effect: Union[list[str], list[RuntimeError]],
+    expected_result: list[int],
 ) -> None:
     """Tests that indices with hash generation failures are reported."""
     input_file = Path("dummy_input.ts")
     output_file = Path("dummy_output.mp4.part")
 
-    mocker.patch("ts2mp4.audio_integrity._get_audio_stream_count", return_value=4)
+    common_streams = (
+        Stream(codec_type="video", index=0),
+        Stream(codec_type="audio", index=1),
+        Stream(codec_type="audio", index=2),
+        Stream(codec_type="audio", index=3),
+    )
+
     mocker.patch(
-        "ts2mp4.audio_integrity.get_stream_md5",
+        "ts2mp4.audio_integrity.get_media_info",
         side_effect=[
-            # Stream 0: Match
-            "stream_0_hash",
-            "stream_0_hash",
-            # Stream 1: Output hash fails
-            "stream_1_input_hash",
-            RuntimeError("ffmpeg error: stream 1 output hash failed"),
-            # Stream 2: Input hash fails
-            RuntimeError("ffmpeg error: stream 2 input hash failed"),
-            "stream_2_output_hash_dummy",  # This won't be reached
-            # Stream 3: Both hashes fail (input fails first)
-            RuntimeError("ffmpeg error: stream 3 input hash failed"),
-            "stream_3_output_hash_dummy",  # This won't be reached
+            MediaInfo(streams=common_streams),  # MediaInfo for input_file
+            MediaInfo(streams=common_streams),  # MediaInfo for output_file
         ],
     )
 
+    mocker.patch("ts2mp4.audio_integrity.get_stream_md5", side_effect=md5_side_effect)
+
     result = get_mismatched_audio_stream_indices(input_file, output_file)
-    assert result == [AudioStreamIndex(1), AudioStreamIndex(2), AudioStreamIndex(3)]
-
-
-@pytest.mark.unit
-def test_get_audio_stream_count_failure(mocker: MockerFixture, ts_file: Path) -> None:
-    """Test _get_audio_stream_count with a non-zero return code."""
-    mocker.patch(
-        "ts2mp4.audio_integrity.get_media_info",
-        side_effect=RuntimeError("ffprobe failed"),
-    )
-    with pytest.raises(RuntimeError, match="ffprobe failed"):
-        _get_audio_stream_count(ts_file)
+    assert result == expected_result
 
 
 @pytest.mark.unit
@@ -117,8 +154,77 @@ def test_get_mismatched_audio_stream_indices_no_audio_streams(
     input_file = Path("dummy_input_no_audio.ts")
     output_file = Path("dummy_output_no_audio.mp4.part")
 
-    mocker.patch("ts2mp4.audio_integrity._get_audio_stream_count", return_value=0)
-    mocker.patch("ts2mp4.audio_integrity.get_stream_md5", return_value="")
+    no_audio_streams = (
+        Stream(codec_type="video", index=0),
+        Stream(codec_type="subtitle", index=1),
+    )
+
+    mocker.patch(
+        "ts2mp4.audio_integrity.get_media_info",
+        side_effect=[
+            MediaInfo(streams=no_audio_streams),
+            MediaInfo(streams=no_audio_streams),
+        ],
+    )
+    mocker.patch("ts2mp4.audio_integrity.get_stream_md5")
 
     result = get_mismatched_audio_stream_indices(input_file, output_file)
     assert result == []
+    mocker.patch("ts2mp4.audio_integrity.get_stream_md5").assert_not_called()
+
+
+@pytest.mark.unit
+def test_get_mismatched_audio_stream_indices_missing_output_stream(
+    mocker: MockerFixture,
+) -> None:
+    input_file = Path("dummy_input.ts")
+    output_file = Path("dummy_output.mp4.part")
+
+    mocker.patch(
+        "ts2mp4.audio_integrity.get_media_info",
+        side_effect=[
+            MediaInfo(
+                streams=(
+                    Stream(codec_type="video", index=0),
+                    Stream(codec_type="audio", index=1),
+                )
+            ),
+            MediaInfo(streams=(Stream(codec_type="video", index=0),)),
+        ],
+    )
+    mocker.patch("ts2mp4.audio_integrity.get_stream_md5")
+
+    result = get_mismatched_audio_stream_indices(input_file, output_file)
+    assert result == [1]
+    mocker.patch("ts2mp4.audio_integrity.get_stream_md5").assert_not_called()
+
+
+@pytest.mark.unit
+def test_get_mismatched_audio_stream_indices_output_stream_type_mismatch(
+    mocker: MockerFixture,
+) -> None:
+    input_file = Path("dummy_input.ts")
+    output_file = Path("dummy_output.mp4.part")
+
+    mocker.patch(
+        "ts2mp4.audio_integrity.get_media_info",
+        side_effect=[
+            MediaInfo(
+                streams=(
+                    Stream(codec_type="video", index=0),
+                    Stream(codec_type="audio", index=1),
+                )
+            ),
+            MediaInfo(
+                streams=(
+                    Stream(codec_type="video", index=0),
+                    Stream(codec_type="subtitle", index=1),
+                )
+            ),
+        ],
+    )
+    mocker.patch("ts2mp4.audio_integrity.get_stream_md5")
+
+    result = get_mismatched_audio_stream_indices(input_file, output_file)
+    assert result == [1]
+    mocker.patch("ts2mp4.audio_integrity.get_stream_md5").assert_not_called()

--- a/tests/test_audio_integrity.py
+++ b/tests/test_audio_integrity.py
@@ -118,7 +118,7 @@ def test_get_mismatched_audio_stream_indices_mismatch(mocker: MockerFixture) -> 
 )
 def test_get_mismatched_audio_stream_indices_hash_failure(
     mocker: MockerFixture,
-    md5_side_effect: Union[list[str], list[RuntimeError]],
+    md5_side_effect: list[Union[str, RuntimeError]],
     expected_result: list[Union[tuple[int, int], tuple[int, None], tuple[None, int]]],
 ) -> None:
     """Tests that indices with hash generation failures are reported."""

--- a/tests/test_audio_integrity.py
+++ b/tests/test_audio_integrity.py
@@ -73,7 +73,7 @@ def test_get_mismatched_audio_stream_indices_mismatch(mocker: MockerFixture) -> 
     )
 
     result = get_mismatched_audio_stream_indices(input_file, output_file)
-    assert result == [1]  # Index of the mismatched audio stream
+    assert result == [(1, 1)]  # Index of the mismatched audio stream
 
 
 @pytest.mark.unit
@@ -89,7 +89,7 @@ def test_get_mismatched_audio_stream_indices_mismatch(mocker: MockerFixture) -> 
                 "stream_3_hash",
                 "stream_3_hash",
             ],
-            [1],
+            [(1, 1)],
             id="output_hash_failure",
         ),
         pytest.param(
@@ -100,7 +100,7 @@ def test_get_mismatched_audio_stream_indices_mismatch(mocker: MockerFixture) -> 
                 "stream_3_hash",
                 "stream_3_hash",
             ],
-            [2],
+            [(2, 2)],
             id="input_hash_failure",
         ),
         pytest.param(
@@ -111,7 +111,7 @@ def test_get_mismatched_audio_stream_indices_mismatch(mocker: MockerFixture) -> 
                 "stream_3_input_ok",
                 RuntimeError("ffmpeg error: stream 3 output failed"),
             ],
-            [1, 2, 3],
+            [(1, 1), (2, 2), (3, 3)],
             id="multiple_hash_failures",
         ),
     ],
@@ -119,7 +119,7 @@ def test_get_mismatched_audio_stream_indices_mismatch(mocker: MockerFixture) -> 
 def test_get_mismatched_audio_stream_indices_hash_failure(
     mocker: MockerFixture,
     md5_side_effect: Union[list[str], list[RuntimeError]],
-    expected_result: list[int],
+    expected_result: list[Union[tuple[int, int], tuple[int, None], tuple[None, int]]],
 ) -> None:
     """Tests that indices with hash generation failures are reported."""
     input_file = Path("dummy_input.ts")
@@ -195,7 +195,7 @@ def test_get_mismatched_audio_stream_indices_missing_output_stream(
     mock_get_stream_md5 = mocker.patch("ts2mp4.audio_integrity.get_stream_md5")
 
     result = get_mismatched_audio_stream_indices(input_file, output_file)
-    assert result == [1]
+    assert result == [(1, None)]
     mock_get_stream_md5.assert_not_called()
 
 
@@ -226,5 +226,5 @@ def test_get_mismatched_audio_stream_indices_output_stream_type_mismatch(
     mock_get_stream_md5 = mocker.patch("ts2mp4.audio_integrity.get_stream_md5")
 
     result = get_mismatched_audio_stream_indices(input_file, output_file)
-    assert result == [1]
+    assert result == [(1, None)]
     mock_get_stream_md5.assert_not_called()

--- a/tests/test_hashing.py
+++ b/tests/test_hashing.py
@@ -9,20 +9,38 @@ from ts2mp4.media_info import Stream
 
 
 @pytest.mark.integration
-def test_get_stream_md5(ts_file: Path) -> None:
-    """Test the get_stream_md5 function for the first stream."""
-    actual_md5 = get_stream_md5(ts_file, Stream(index=1, codec_type="audio"))
+@pytest.mark.parametrize(
+    "stream_index, codec_type",
+    [
+        (0, "video"),  # Video stream
+        (1, "audio"),  # Audio stream
+    ],
+)
+def test_get_stream_md5(ts_file: Path, stream_index: int, codec_type: str) -> None:
+    """Test the get_stream_md5 function for different stream types."""
+    stream = Stream(index=stream_index, codec_type=codec_type)
+    actual_md5 = get_stream_md5(ts_file, stream)
     # Check if the returned MD5 hash is a valid 32-character hexadecimal string
     assert len(actual_md5) == 32
     assert all(c in "0123456789abcdef" for c in actual_md5)
 
 
 @pytest.mark.unit
-def test_get_stream_md5_failure(mocker: MockerFixture, ts_file: Path) -> None:
-    """Test get_stream_md5 with a non-zero return code."""
+@pytest.mark.parametrize(
+    "stream_index, codec_type",
+    [
+        (0, "video"),  # Video stream
+        (1, "audio"),  # Audio stream
+    ],
+)
+def test_get_stream_md5_failure(
+    mocker: MockerFixture, ts_file: Path, stream_index: int, codec_type: str
+) -> None:
+    """Test get_stream_md5 with a non-zero return code for different stream types."""
     mock_execute_ffmpeg = mocker.patch("ts2mp4.hashing.execute_ffmpeg")
     mock_execute_ffmpeg.return_value = FFmpegResult(
         stdout=b"", stderr="ffmpeg error", returncode=1
     )
+    stream = Stream(index=stream_index, codec_type=codec_type)
     with pytest.raises(RuntimeError, match="ffmpeg failed"):
-        get_stream_md5(ts_file, Stream(index=1, codec_type="audio"))
+        get_stream_md5(ts_file, stream)

--- a/tests/test_hashing.py
+++ b/tests/test_hashing.py
@@ -5,12 +5,13 @@ from pytest_mock import MockerFixture
 
 from ts2mp4.ffmpeg import FFmpegResult
 from ts2mp4.hashing import get_stream_md5
+from ts2mp4.media_info import Stream
 
 
 @pytest.mark.integration
 def test_get_stream_md5(ts_file: Path) -> None:
     """Test the get_stream_md5 function for the first stream."""
-    actual_md5 = get_stream_md5(ts_file, 0)
+    actual_md5 = get_stream_md5(ts_file, Stream(index=1, codec_type="audio"))
     # Check if the returned MD5 hash is a valid 32-character hexadecimal string
     assert len(actual_md5) == 32
     assert all(c in "0123456789abcdef" for c in actual_md5)
@@ -24,4 +25,4 @@ def test_get_stream_md5_failure(mocker: MockerFixture, ts_file: Path) -> None:
         stdout=b"", stderr="ffmpeg error", returncode=1
     )
     with pytest.raises(RuntimeError, match="ffmpeg failed"):
-        get_stream_md5(ts_file, 0)
+        get_stream_md5(ts_file, Stream(index=1, codec_type="audio"))

--- a/tests/test_hashing.py
+++ b/tests/test_hashing.py
@@ -4,34 +4,24 @@ import pytest
 from pytest_mock import MockerFixture
 
 from ts2mp4.ffmpeg import FFmpegResult
-from ts2mp4.hashing import StreamType, get_stream_md5
+from ts2mp4.hashing import get_stream_md5
 
 
 @pytest.mark.integration
-@pytest.mark.parametrize(
-    "stream_type",
-    ["video", "audio"],
-)
-def test_get_stream_md5(ts_file: Path, stream_type: StreamType) -> None:
-    """Test the get_stream_md5 function for both video and audio streams."""
-    actual_md5 = get_stream_md5(ts_file, stream_type, 0)
+def test_get_stream_md5(ts_file: Path) -> None:
+    """Test the get_stream_md5 function for the first stream."""
+    actual_md5 = get_stream_md5(ts_file, 0)
     # Check if the returned MD5 hash is a valid 32-character hexadecimal string
     assert len(actual_md5) == 32
     assert all(c in "0123456789abcdef" for c in actual_md5)
 
 
 @pytest.mark.unit
-@pytest.mark.parametrize(
-    "stream_type",
-    ["audio", "video"],
-)
-def test_get_stream_md5_failure(
-    mocker: MockerFixture, ts_file: Path, stream_type: StreamType
-) -> None:
+def test_get_stream_md5_failure(mocker: MockerFixture, ts_file: Path) -> None:
     """Test get_stream_md5 with a non-zero return code."""
     mock_execute_ffmpeg = mocker.patch("ts2mp4.hashing.execute_ffmpeg")
     mock_execute_ffmpeg.return_value = FFmpegResult(
         stdout=b"", stderr="ffmpeg error", returncode=1
     )
     with pytest.raises(RuntimeError, match="ffmpeg failed"):
-        get_stream_md5(ts_file, stream_type, 0)
+        get_stream_md5(ts_file, 0)

--- a/tests/test_media_info.py
+++ b/tests/test_media_info.py
@@ -20,7 +20,10 @@ def test_get_media_info_success(mocker: MockerFixture) -> None:
     mock_execute_ffprobe = mocker.patch("ts2mp4.media_info.execute_ffprobe")
     file_path = Path("test.ts")
     ffprobe_output = {
-        "streams": [{"codec_type": "video"}, {"codec_type": "audio"}],
+        "streams": [
+            {"codec_type": "video", "index": 0},
+            {"codec_type": "audio", "index": 1},
+        ],
         "format": {"format_name": "mpegts"},
     }
     mock_result = MagicMock()
@@ -34,8 +37,8 @@ def test_get_media_info_success(mocker: MockerFixture) -> None:
     # Assert
     expected = MediaInfo(
         streams=(
-            Stream(codec_type="video"),
-            Stream(codec_type="audio"),
+            Stream(codec_type="video", index=0),
+            Stream(codec_type="audio", index=1),
         ),
         format=Format(format_name="mpegts"),
     )
@@ -110,7 +113,10 @@ def test_get_media_info_cached(mocker: MockerFixture) -> None:
     mock_execute_ffprobe = mocker.patch("ts2mp4.media_info.execute_ffprobe")
     file_path = Path("test.ts")
     ffprobe_output = {
-        "streams": [{"codec_type": "video"}, {"codec_type": "audio"}],
+        "streams": [
+            {"codec_type": "video", "index": 0},
+            {"codec_type": "audio", "index": 1},
+        ],
         "format": {"format_name": "mpegts"},
     }
     mock_result = MagicMock()
@@ -134,10 +140,11 @@ def test_get_media_info_integration(ts_file: Path) -> None:
     result = get_media_info(ts_file)
 
     # Assert
+    # Assuming a real ts file has at least one video and one audio stream at indices 0 and 1
     expected = MediaInfo(
         streams=(
-            Stream(codec_type="video"),
-            Stream(codec_type="audio"),
+            Stream(codec_type="video", index=0),
+            Stream(codec_type="audio", index=1),
         ),
         format=Format(format_name="mpegts"),
     )

--- a/tests/test_ts2mp4.py
+++ b/tests/test_ts2mp4.py
@@ -145,12 +145,12 @@ def test_ts2mp4_raises_runtime_error_on_audio_integrity_failure(
     mock_execute_ffmpeg.return_value = FFmpegResult(stdout=b"", stderr="", returncode=0)
     mocker.patch(
         "ts2mp4.ts2mp4.get_mismatched_audio_stream_indices",
-        return_value=[0, 2],
+        return_value=[(0, 0), (2, 2)],
     )
 
     # Act & Assert
     with pytest.raises(
         RuntimeError,
-        match=r"Audio stream integrity check failed for indices: \[0, 2\]",
+        match=r"Audio stream integrity check failed for pairs: \[\(0, 0\), \(2, 2\)\]",
     ):
         ts2mp4(input_file, output_file, crf, preset)

--- a/tests/test_ts2mp4.py
+++ b/tests/test_ts2mp4.py
@@ -5,7 +5,6 @@ from pytest_mock import MockerFixture
 
 from ts2mp4.ffmpeg import FFmpegResult
 from ts2mp4.ts2mp4 import ts2mp4
-from ts2mp4.types import AudioStreamIndex
 
 
 @pytest.mark.unit
@@ -146,12 +145,12 @@ def test_ts2mp4_raises_runtime_error_on_audio_integrity_failure(
     mock_execute_ffmpeg.return_value = FFmpegResult(stdout=b"", stderr="", returncode=0)
     mocker.patch(
         "ts2mp4.ts2mp4.get_mismatched_audio_stream_indices",
-        return_value=[AudioStreamIndex(0), AudioStreamIndex(2)],
+        return_value=[0, 2],
     )
 
     # Act & Assert
     with pytest.raises(
         RuntimeError,
-        match="Audio stream integrity check failed for indices: \\[0, 2\\]",
+        match=r"Audio stream integrity check failed for indices: \[0, 2\]",
     ):
         ts2mp4(input_file, output_file, crf, preset)

--- a/ts2mp4/audio_integrity.py
+++ b/ts2mp4/audio_integrity.py
@@ -46,6 +46,7 @@ def get_mismatched_audio_stream_indices(
     This function compares the MD5 hashes of audio streams between an input and output file.
     It identifies streams where the hashes do not match or where hash generation fails for
     either the input or output stream.
+    It assumes that the order of audio streams in the input and output files corresponds.
 
     Args:
         input_file: Path to the original input file.

--- a/ts2mp4/audio_integrity.py
+++ b/ts2mp4/audio_integrity.py
@@ -20,17 +20,24 @@ def _check_stream_integrity(
     """
     try:
         input_md5 = get_stream_md5(input_file, input_stream)
-        output_md5 = get_stream_md5(output_file, output_stream)
-
-        if input_md5 != output_md5:
-            logger.warning(
-                f"Mismatch in stream at index {input_stream.index}: "
-                f"Input MD5: {input_md5}, Output MD5: {output_md5}"
-            )
-            return False
     except RuntimeError as e:
         logger.warning(
-            f"Failed to get MD5 for stream at index {input_stream.index}: {e}"
+            f"Failed to get MD5 for input stream at index {input_stream.index}: {e}"
+        )
+        return False
+
+    try:
+        output_md5 = get_stream_md5(output_file, output_stream)
+    except RuntimeError as e:
+        logger.warning(
+            f"Failed to get MD5 for output stream at index {output_stream.index}: {e}"
+        )
+        return False
+
+    if input_md5 != output_md5:
+        logger.warning(
+            f"Mismatch in stream at index {input_stream.index}: "
+            f"Input MD5: {input_md5}, Output MD5: {output_md5}"
         )
         return False
 

--- a/ts2mp4/audio_integrity.py
+++ b/ts2mp4/audio_integrity.py
@@ -74,17 +74,14 @@ def get_mismatched_audio_stream_indices(
     output_media_info = get_media_info(output_file)
 
     mismatched_indices: list[tuple[Optional[int], Optional[int]]] = []
+    input_audio_streams = (
+        stream for stream in input_media_info.streams if stream.codec_type == "audio"
+    )
+    output_audio_streams = (
+        stream for stream in output_media_info.streams if stream.codec_type == "audio"
+    )
     for input_audio_stream, output_audio_stream in itertools.zip_longest(
-        (
-            audio_stream
-            for audio_stream in input_media_info.streams
-            if audio_stream.codec_type == "audio"
-        ),
-        (
-            audio_stream
-            for audio_stream in output_media_info.streams
-            if audio_stream.codec_type == "audio"
-        ),
+        input_audio_streams, output_audio_streams
     ):
         input_idx = input_audio_stream.index if input_audio_stream else None
         output_idx = output_audio_stream.index if output_audio_stream else None

--- a/ts2mp4/audio_integrity.py
+++ b/ts2mp4/audio_integrity.py
@@ -1,33 +1,47 @@
+import itertools
 from pathlib import Path
 
 from logzero import logger
 
 from .hashing import get_stream_md5
-from .media_info import get_media_info
-from .types import AudioStreamIndex
+from .media_info import Stream, get_media_info
 
 
-def _get_audio_stream_count(file_path: Path) -> int:
-    """Return the number of audio streams in a given file.
-
-    Args:
-    ----
-        file_path: The path to the input file.
+def _check_stream_integrity(
+    input_file: Path,
+    output_file: Path,
+    input_stream: Stream,
+    output_stream: Stream,
+) -> bool:
+    """Checks the integrity of a single stream by comparing MD5 hashes.
 
     Returns:
-    -------
-        The number of audio streams.
-
+        True if the stream hashes match and hash generation is successful, False otherwise.
     """
-    media_info = get_media_info(file_path)
-    return sum(1 for stream in media_info.streams if stream.codec_type == "audio")
+    try:
+        input_md5 = get_stream_md5(input_file, input_stream.index)
+        output_md5 = get_stream_md5(output_file, output_stream.index)
+
+        if input_md5 != output_md5:
+            logger.warning(
+                f"Mismatch in stream at index {input_stream.index}: "
+                f"Input MD5: {input_md5}, Output MD5: {output_md5}"
+            )
+            return False
+    except RuntimeError as e:
+        logger.warning(
+            f"Failed to get MD5 for stream at index {input_stream.index}: {e}"
+        )
+        return False
+
+    return True
 
 
 def get_mismatched_audio_stream_indices(
     input_file: Path, output_file: Path
-) -> list[AudioStreamIndex]:
+) -> list[int]:
     """
-    Verifies audio stream integrity by comparing MD5 hashes, returning problematic indices.
+    Verifies audio stream integrity by comparing MD5 hashes, returning problematic stream indices.
 
     This function compares the MD5 hashes of audio streams between an input and output file.
     It identifies streams where the hashes do not match or where hash generation fails for
@@ -38,30 +52,46 @@ def get_mismatched_audio_stream_indices(
         output_file: Path to the converted output file.
 
     Returns:
-        A list of audio stream indices for streams that have mismatched or failed MD5 hashes.
+        A list of stream indices for audio streams that have mismatched or failed MD5 hashes.
         An empty list is returned if all audio streams are verified successfully.
     """
     logger.info(
         f"Verifying audio stream integrity for {input_file.name} and {output_file.name}"
     )
-    audio_stream_count = _get_audio_stream_count(input_file)
-    logger.info(f"Detected {audio_stream_count} audio streams in input file.")
+
+    input_media_info = get_media_info(input_file)
+    output_media_info = get_media_info(output_file)
 
     mismatched_indices = []
-    for i in range(audio_stream_count):
-        try:
-            input_md5 = get_stream_md5(input_file, "audio", i)
-            output_md5 = get_stream_md5(output_file, "audio", i)
+    for input_stream, output_stream in itertools.zip_longest(
+        input_media_info.streams, output_media_info.streams
+    ):
+        if (
+            input_stream is None
+        ):  # Should not happen if input_media_info.streams is the primary source
+            continue
 
-            if input_md5 != output_md5:
+        if input_stream.codec_type == "audio":
+            stream_index = input_stream.index
+
+            if output_stream is None:
                 logger.warning(
-                    f"Mismatch in audio stream {i}: "
-                    f"Input MD5: {input_md5}, Output MD5: {output_md5}"
+                    f"Audio stream at index {stream_index} in input file has no corresponding stream in output file."
                 )
-                mismatched_indices.append(AudioStreamIndex(i))
-        except RuntimeError as e:
-            logger.warning(f"Failed to get MD5 for audio stream {i}: {e}")
-            mismatched_indices.append(AudioStreamIndex(i))
+                mismatched_indices.append(stream_index)
+                continue
+
+            if output_stream.codec_type != "audio":
+                logger.warning(
+                    f"Stream at index {stream_index} in output file is not an audio stream (found {output_stream.codec_type})."
+                )
+                mismatched_indices.append(stream_index)
+                continue
+
+            if not _check_stream_integrity(
+                input_file, output_file, input_stream, output_stream
+            ):
+                mismatched_indices.append(stream_index)
 
     if not mismatched_indices:
         logger.info(

--- a/ts2mp4/audio_integrity.py
+++ b/ts2mp4/audio_integrity.py
@@ -19,8 +19,8 @@ def _check_stream_integrity(
         True if the stream hashes match and hash generation is successful, False otherwise.
     """
     try:
-        input_md5 = get_stream_md5(input_file, input_stream.index)
-        output_md5 = get_stream_md5(output_file, output_stream.index)
+        input_md5 = get_stream_md5(input_file, input_stream)
+        output_md5 = get_stream_md5(output_file, output_stream)
 
         if input_md5 != output_md5:
             logger.warning(

--- a/ts2mp4/hashing.py
+++ b/ts2mp4/hashing.py
@@ -1,11 +1,12 @@
 import hashlib
 from pathlib import Path
 
+from ts2mp4.media_info import Stream
+
 from .ffmpeg import execute_ffmpeg
-from .media_info import get_media_info
 
 
-def get_stream_md5(file_path: Path, stream_index: int) -> str:
+def get_stream_md5(file_path: Path, stream: Stream) -> str:
     """Calculate the MD5 hash of a decoded stream of a given file using its stream index.
 
     Args:
@@ -23,13 +24,6 @@ def get_stream_md5(file_path: Path, stream_index: int) -> str:
         RuntimeError: If ffmpeg fails to extract the stream.
 
     """
-    media_info = get_media_info(file_path)
-
-    if stream_index >= len(media_info.streams) or stream_index < 0:
-        raise ValueError(f"Invalid stream index: {stream_index}")
-
-    stream = media_info.streams[stream_index]
-
     if stream.codec_type == "audio":
         output_format = "s16le"
         stream_disabling_arg = "-vn"  # Disable video stream
@@ -48,7 +42,7 @@ def get_stream_md5(file_path: Path, stream_index: int) -> str:
         str(file_path),
         stream_disabling_arg,
         "-map",
-        f"0:{stream_index}",
+        f"0:{stream.index}",
         "-f",
         output_format,
         "-",  # Output to stdout

--- a/ts2mp4/hashing.py
+++ b/ts2mp4/hashing.py
@@ -26,10 +26,8 @@ def get_stream_md5(file_path: Path, stream: Stream) -> str:
     """
     if stream.codec_type == "audio":
         output_format = "s16le"
-        stream_disabling_arg = "-vn"  # Disable video stream
     elif stream.codec_type == "video":
         output_format = "rawvideo"
-        stream_disabling_arg = "-an"  # Disable audio stream
     else:
         raise ValueError(
             f"Unsupported stream type for MD5 calculation: {stream.codec_type}. "
@@ -40,7 +38,6 @@ def get_stream_md5(file_path: Path, stream: Stream) -> str:
         "-hide_banner",
         "-i",
         str(file_path),
-        stream_disabling_arg,
         "-map",
         f"0:{stream.index}",
         "-f",

--- a/ts2mp4/hashing.py
+++ b/ts2mp4/hashing.py
@@ -7,12 +7,12 @@ from .ffmpeg import execute_ffmpeg
 
 
 def get_stream_md5(file_path: Path, stream: Stream) -> str:
-    """Calculate the MD5 hash of a decoded stream of a given file using its stream index.
+    """Calculate the MD5 hash of a decoded stream of a given file.
 
     Args:
     ----
         file_path: The path to the input file.
-        stream_index: The 0-based index of the stream to process within the file.
+        stream: The stream object to process.
 
     Returns:
     -------
@@ -20,7 +20,7 @@ def get_stream_md5(file_path: Path, stream: Stream) -> str:
 
     Raises:
     ------
-        ValueError: If the stream index is invalid or the stream type is unsupported.
+        ValueError: If the stream type is unsupported.
         RuntimeError: If ffmpeg fails to extract the stream.
 
     """

--- a/ts2mp4/hashing.py
+++ b/ts2mp4/hashing.py
@@ -1,20 +1,17 @@
 import hashlib
 from pathlib import Path
-from typing import Literal
 
 from .ffmpeg import execute_ffmpeg
+from .media_info import get_media_info
 
-StreamType = Literal["audio", "video"]
 
-
-def get_stream_md5(file_path: Path, stream_type: StreamType, stream_index: int) -> str:
-    """Calculate the MD5 hash of a decoded stream of a given file.
+def get_stream_md5(file_path: Path, stream_index: int) -> str:
+    """Calculate the MD5 hash of a decoded stream of a given file using its stream index.
 
     Args:
     ----
         file_path: The path to the input file.
-        stream_type: The type of the stream to process ('audio' or 'video').
-        stream_index: The index of the stream to process.
+        stream_index: The 0-based index of the stream to process within the file.
 
     Returns:
     -------
@@ -22,20 +19,27 @@ def get_stream_md5(file_path: Path, stream_type: StreamType, stream_index: int) 
 
     Raises:
     ------
+        ValueError: If the stream index is invalid or the stream type is unsupported.
         RuntimeError: If ffmpeg fails to extract the stream.
 
     """
-    if stream_type == "audio":
-        map_specifier = f"0:a:{stream_index}"
+    media_info = get_media_info(file_path)
+
+    if stream_index >= len(media_info.streams) or stream_index < 0:
+        raise ValueError(f"Invalid stream index: {stream_index}")
+
+    stream = media_info.streams[stream_index]
+
+    if stream.codec_type == "audio":
         output_format = "s16le"
         stream_disabling_arg = "-vn"  # Disable video stream
-    elif stream_type == "video":
-        map_specifier = f"0:v:{stream_index}"
+    elif stream.codec_type == "video":
         output_format = "rawvideo"
         stream_disabling_arg = "-an"  # Disable audio stream
     else:
         raise ValueError(
-            f"Invalid stream_type: {stream_type}. Must be 'audio' or 'video'."
+            f"Unsupported stream type for MD5 calculation: {stream.codec_type}. "
+            "Only 'audio' and 'video' are supported."
         )
 
     ffmpeg_args = [
@@ -44,7 +48,7 @@ def get_stream_md5(file_path: Path, stream_type: StreamType, stream_index: int) 
         str(file_path),
         stream_disabling_arg,
         "-map",
-        map_specifier,
+        f"0:{stream_index}",
         "-f",
         output_format,
         "-",  # Output to stdout
@@ -52,7 +56,7 @@ def get_stream_md5(file_path: Path, stream_type: StreamType, stream_index: int) 
     result = execute_ffmpeg(ffmpeg_args)
     if result.returncode != 0:
         raise RuntimeError(
-            f"ffmpeg failed to get decoded {stream_type} stream for {file_path}. "
+            f"ffmpeg failed to get decoded {stream.codec_type} stream for {file_path}. "
             f"Return code: {result.returncode}"
         )
     return hashlib.md5(result.stdout).hexdigest()

--- a/ts2mp4/media_info.py
+++ b/ts2mp4/media_info.py
@@ -13,6 +13,7 @@ class Stream(BaseModel):
 
     model_config = ConfigDict(frozen=True)
 
+    index: int
     codec_type: Optional[str] = None
 
 

--- a/ts2mp4/ts2mp4.py
+++ b/ts2mp4/ts2mp4.py
@@ -64,5 +64,5 @@ def ts2mp4(input_file: Path, output_file: Path, crf: int, preset: str) -> None:
     )
     if mismatched_indices:
         raise RuntimeError(
-            f"Audio stream integrity check failed for indices: {mismatched_indices}"
+            f"Audio stream integrity check failed for pairs: {mismatched_indices}"
         )

--- a/ts2mp4/types.py
+++ b/ts2mp4/types.py
@@ -1,3 +1,0 @@
-from typing import NewType
-
-AudioStreamIndex = NewType("AudioStreamIndex", int)


### PR DESCRIPTION
This commit refactors the audio stream integrity check logic and updates media information handling.

Key changes include:
- Removed `AudioStreamIndex` type and related imports/usages.
- Refactored `get_mismatched_audio_stream_indices` to use `MediaInfo` and `Stream` objects, improving stream comparison and error handling.
- Updated `get_stream_md5` to no longer require `stream_type` and to use `get_media_info` for codec type determination.
- Added `index` field to `Stream` model in `media_info.py`.
- Updated tests to reflect these changes, including new test cases for various scenarios.
