### PR TITLE
feat: shorten test video duration to 3 seconds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,11 +19,11 @@ format:
 
 $(TEST_ASSETS_DIR)/test_video.ts: Makefile
 	@mkdir -p $(TEST_ASSETS_DIR)
-	@echo "Generating a 10-second dummy video and audio for testing..."
+	@echo "Generating a 3-second dummy video and audio for testing..."
 	ffmpeg \
 		-y \
 		-f lavfi \
-		-i "avsynctest=duration=10[out0][out1]" \
+		-i "avsynctest=duration=3[out0][out1]" \
 		-codec:a aac \
 		$@
 	@echo "Dummy video '$@' generated successfully."


### PR DESCRIPTION
The test video generation in the Makefile now creates a 3-second video instead of a 10-second one. This change speeds up tests that rely on the test video.