### PR TITLE
feat: update test video generation to include two audio streams

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,14 @@ $(TEST_ASSETS_DIR)/test_video.ts: Makefile
 		-y \
 		-f lavfi \
 		-i "avsynctest=duration=10[out0][out1]" \
+		-f lavfi \
+		-i "sine=frequency=1000:duration=10" \
+		-map 0:1 \
+		-map 0:0 \
+		-map 1:0 \
+		-codec:v mpeg2video \
 		-codec:a aac \
+		-shortest \
 		$@
 	@echo "Dummy video '$@' generated successfully."
 

--- a/Makefile
+++ b/Makefile
@@ -26,9 +26,9 @@ $(TEST_ASSETS_DIR)/test_video.ts: Makefile
 		-i "avsynctest=duration=10[out0][out1]" \
 		-f lavfi \
 		-i "sine=frequency=1000:duration=10" \
-		-map 0:1 \
-		-map 0:0 \
-		-map 1:0 \
+		-map 0:v:0 \
+		-map 0:a:0 \
+		-map 1:a:0 \
 		-codec:v mpeg2video \
 		-codec:a aac \
 		-shortest \

--- a/tests/test_audio_integrity.py
+++ b/tests/test_audio_integrity.py
@@ -13,7 +13,7 @@ from ts2mp4.types import AudioStreamIndex
 @pytest.mark.integration
 def test_get_audio_stream_count(ts_file: Path) -> None:
     """Test the _get_audio_stream_count helper function."""
-    expected_stream_count = 1
+    expected_stream_count = 2
     actual_stream_count = _get_audio_stream_count(ts_file)
     assert actual_stream_count == expected_stream_count
 

--- a/tests/test_media_info.py
+++ b/tests/test_media_info.py
@@ -20,7 +20,11 @@ def test_get_media_info_success(mocker: MockerFixture) -> None:
     mock_execute_ffprobe = mocker.patch("ts2mp4.media_info.execute_ffprobe")
     file_path = Path("test.ts")
     ffprobe_output = {
-        "streams": [{"codec_type": "video"}, {"codec_type": "audio"}],
+        "streams": [
+            {"codec_type": "video"},
+            {"codec_type": "audio"},
+            {"codec_type": "audio"},
+        ],
         "format": {"format_name": "mpegts"},
     }
     mock_result = MagicMock()
@@ -35,6 +39,7 @@ def test_get_media_info_success(mocker: MockerFixture) -> None:
     expected = MediaInfo(
         streams=(
             Stream(codec_type="video"),
+            Stream(codec_type="audio"),
             Stream(codec_type="audio"),
         ),
         format=Format(format_name="mpegts"),
@@ -137,6 +142,7 @@ def test_get_media_info_integration(ts_file: Path) -> None:
     expected = MediaInfo(
         streams=(
             Stream(codec_type="video"),
+            Stream(codec_type="audio"),
             Stream(codec_type="audio"),
         ),
         format=Format(format_name="mpegts"),


### PR DESCRIPTION
The Makefile now generates a test video with two audio streams. This allows for more realistic testing of the audio processing functionality.

The tests have been updated to reflect this change.