### PR TITLE
feat: Add caching to get_stream_md5

### DIFF
--- a/tests/test_hashing.py
+++ b/tests/test_hashing.py
@@ -8,6 +8,25 @@ from ts2mp4.hashing import get_stream_md5
 from ts2mp4.media_info import Stream
 
 
+@pytest.mark.unit
+def test_get_stream_md5_caching(mocker: MockerFixture) -> None:
+    """Test that get_stream_md5 caches results."""
+    file_path = Path("test.ts")
+    stream = Stream(index=0, codec_type="video")
+
+    mock_execute_ffmpeg = mocker.patch(
+        "ts2mp4.hashing.execute_ffmpeg",
+        return_value=FFmpegResult(stdout=b"stream_data", stderr="", returncode=0),
+    )
+
+    # Call twice
+    get_stream_md5(file_path, stream)
+    get_stream_md5(file_path, stream)
+
+    # Assert that execute_ffmpeg was only called once
+    mock_execute_ffmpeg.assert_called_once()
+
+
 @pytest.mark.integration
 @pytest.mark.parametrize(
     "stream_index, codec_type",

--- a/tests/test_hashing.py
+++ b/tests/test_hashing.py
@@ -20,7 +20,8 @@ def test_get_stream_md5_caching(mocker: MockerFixture) -> None:
     file_path = Path("test.ts")
     stream = Stream(index=0, codec_type="video")
 
-    mocker.patch("pathlib.Path.stat", return_value=mocker.Mock(st_mtime=1, st_size=1))
+    mock_resolve = mocker.patch.object(Path, "resolve", return_value=file_path)
+    mocker.patch.object(Path, "stat", return_value=mocker.Mock(st_mtime=1, st_size=1))
 
     mock_execute_ffmpeg = mocker.patch(
         "ts2mp4.hashing.execute_ffmpeg",
@@ -33,6 +34,7 @@ def test_get_stream_md5_caching(mocker: MockerFixture) -> None:
 
     # Assert that execute_ffmpeg was only called once
     mock_execute_ffmpeg.assert_called_once()
+    mock_resolve.assert_called_with(strict=True)
 
 
 @pytest.mark.unit
@@ -41,6 +43,7 @@ def test_get_stream_md5_cache_invalidation(mocker: MockerFixture) -> None:
     file_path = Path("test.ts")
     stream = Stream(index=0, codec_type="video")
 
+    mock_resolve = mocker.patch.object(Path, "resolve", return_value=file_path)
     mock_stat = mocker.patch(
         "pathlib.Path.stat", return_value=mocker.Mock(st_mtime=1, st_size=1)
     )
@@ -61,6 +64,7 @@ def test_get_stream_md5_cache_invalidation(mocker: MockerFixture) -> None:
 
     # Assert that execute_ffmpeg was called twice
     assert mock_execute_ffmpeg.call_count == 2
+    mock_resolve.assert_called_with(strict=True)
 
 
 @pytest.mark.integration

--- a/tests/test_hashing.py
+++ b/tests/test_hashing.py
@@ -4,8 +4,14 @@ import pytest
 from pytest_mock import MockerFixture
 
 from ts2mp4.ffmpeg import FFmpegResult
-from ts2mp4.hashing import get_stream_md5
+from ts2mp4.hashing import _get_stream_md5_cached, get_stream_md5
 from ts2mp4.media_info import Stream
+
+
+@pytest.fixture(autouse=True)
+def _clear_hashing_cache() -> None:
+    """A fixture to automatically clear the cache for get_stream_md5 before each test."""
+    _get_stream_md5_cached.cache_clear()
 
 
 @pytest.mark.unit
@@ -27,6 +33,34 @@ def test_get_stream_md5_caching(mocker: MockerFixture) -> None:
 
     # Assert that execute_ffmpeg was only called once
     mock_execute_ffmpeg.assert_called_once()
+
+
+@pytest.mark.unit
+def test_get_stream_md5_cache_invalidation(mocker: MockerFixture) -> None:
+    """Test that the cache is invalidated when the file is modified."""
+    file_path = Path("test.ts")
+    stream = Stream(index=0, codec_type="video")
+
+    mock_stat = mocker.patch(
+        "pathlib.Path.stat", return_value=mocker.Mock(st_mtime=1, st_size=1)
+    )
+
+    mock_execute_ffmpeg = mocker.patch(
+        "ts2mp4.hashing.execute_ffmpeg",
+        return_value=FFmpegResult(stdout=b"stream_data", stderr="", returncode=0),
+    )
+
+    # First call
+    get_stream_md5(file_path, stream)
+
+    # Simulate file modification
+    mock_stat.return_value = mocker.Mock(st_mtime=2, st_size=2)
+
+    # Second call
+    get_stream_md5(file_path, stream)
+
+    # Assert that execute_ffmpeg was called twice
+    assert mock_execute_ffmpeg.call_count == 2
 
 
 @pytest.mark.integration

--- a/tests/test_hashing.py
+++ b/tests/test_hashing.py
@@ -14,6 +14,8 @@ def test_get_stream_md5_caching(mocker: MockerFixture) -> None:
     file_path = Path("test.ts")
     stream = Stream(index=0, codec_type="video")
 
+    mocker.patch("pathlib.Path.stat", return_value=mocker.Mock(st_mtime=1, st_size=1))
+
     mock_execute_ffmpeg = mocker.patch(
         "ts2mp4.hashing.execute_ffmpeg",
         return_value=FFmpegResult(stdout=b"stream_data", stderr="", returncode=0),

--- a/ts2mp4/hashing.py
+++ b/ts2mp4/hashing.py
@@ -1,4 +1,5 @@
 import hashlib
+from functools import cache
 from pathlib import Path
 
 from ts2mp4.media_info import Stream
@@ -6,6 +7,7 @@ from ts2mp4.media_info import Stream
 from .ffmpeg import execute_ffmpeg
 
 
+@cache
 def get_stream_md5(file_path: Path, stream: Stream) -> str:
     """Calculate the MD5 hash of a decoded stream of a given file.
 

--- a/ts2mp4/hashing.py
+++ b/ts2mp4/hashing.py
@@ -58,5 +58,6 @@ def get_stream_md5(file_path: Path, stream: Stream) -> str:
         RuntimeError: If ffmpeg fails to extract the stream.
 
     """
-    stat = file_path.stat()
-    return _get_stream_md5_cached(file_path, stat.st_mtime, stat.st_size, stream)
+    resolved_path = file_path.resolve(strict=True)
+    stat = resolved_path.stat()
+    return _get_stream_md5_cached(resolved_path, stat.st_mtime, stat.st_size, stream)


### PR DESCRIPTION
Caches the results of get_stream_md5 to improve performance by avoiding redundant ffmpeg process calls for the same file and stream. This is particularly beneficial when the same stream is accessed multiple times, such as during audio integrity checks.