### PR TITLE
feat: Add format-and-check target to Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,6 +18,9 @@ format:
 	poetry run ruff check . --fix
 	poetry run ruff format .
 
+.PHONY: format-and-check
+format-and-check: format check
+
 $(TEST_ASSETS_DIR)/test_video.ts: Makefile
 	@mkdir -p $(TEST_ASSETS_DIR)
 	@echo "Generating a $(TEST_VIDEO_DURATION)-second dummy video and audio for testing..."

--- a/README.md
+++ b/README.md
@@ -39,15 +39,20 @@ make check
 ```
 
 This command executes:
-*   `black --check .` (code formatting)
-*   `isort --check .` (import sorting)
-*   `flake8 .` (linting)
+*   `ruff check .` (linting)
+*   `ruff format --check .` (code formatting check)
 *   `mypy .` (type checking)
 *   `pytest` (unit and integration tests)
 
+For convenience, you can run formatting and all checks at once with the following command:
+
+```bash
+make format-and-check
+```
+
 ### Code Formatting
 
-To format the code using `black` and `isort`:
+To format the code using `ruff`:
 
 ```bash
 make format


### PR DESCRIPTION
This commit introduces a new `format-and-check` target to the `Makefile`. This allows you to run both code formatting and all checks (linting, type checking, tests) with a single command.

The `README.md` has been updated to:
- Reflect the usage of `ruff` for linting and formatting.
- Include the new `format-and-check` command in the 'Running Tests and Code Quality Checks' section for better visibility.