### PR TITLE
feat: Add poetry sync before make check and format

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,15 @@
 TEST_ASSETS_DIR = tests/assets
 TEST_VIDEO_DURATION := 3
 
+.PHONY: all
+all: check
+
+.PHONY: sync
+sync:
+	poetry sync
+
 .PHONY: check
-check: $(TEST_ASSETS_DIR)/test_video.ts
+check: sync $(TEST_ASSETS_DIR)/test_video.ts
 	poetry run ruff check .
 	poetry run ruff format --check .
 	poetry run mypy .
@@ -14,7 +21,7 @@ check: $(TEST_ASSETS_DIR)/test_video.ts
 	poetry run pytest -m e2e
 
 .PHONY: format
-format:
+format: sync
 	poetry run ruff check . --fix
 	poetry run ruff format .
 


### PR DESCRIPTION
This change introduces a `sync` target in the `Makefile` that runs `poetry sync`. The `check` and `format` targets are now dependent on the `sync` target, ensuring that all dependencies are synchronized before running any checks or tests.

Additionally, the `check` target is now the default goal when running `make` without arguments. This improves the reliability and consistency of the CI/CD process.