### PR TITLE
Revert audio stream integrity verification logic

### DIFF
--- a/tests/test_ts2mp4.py
+++ b/tests/test_ts2mp4.py
@@ -18,7 +18,7 @@ def test_calls_execute_ffmpeg_with_correct_args(mocker: MockerFixture) -> None:
 
     mock_execute_ffmpeg = mocker.patch("ts2mp4.ts2mp4.execute_ffmpeg")
     mock_execute_ffmpeg.return_value = FFmpegResult(stdout=b"", stderr="", returncode=0)
-    mocker.patch("ts2mp4.ts2mp4.get_mismatched_audio_stream_indices", return_value=[])
+    mocker.patch("ts2mp4.ts2mp4.verify_audio_stream_integrity")
 
     # Act
     ts2mp4(input_file, output_file, crf, preset)
@@ -62,7 +62,7 @@ def test_calls_execute_ffmpeg_with_correct_args(mocker: MockerFixture) -> None:
 
 
 @pytest.mark.unit
-def test_calls_get_mismatched_audio_stream_indices_on_success(
+def test_calls_verify_audio_stream_integrity_on_success(
     mocker: MockerFixture,
 ) -> None:
     # Arrange
@@ -73,15 +73,15 @@ def test_calls_get_mismatched_audio_stream_indices_on_success(
 
     mock_execute_ffmpeg = mocker.patch("ts2mp4.ts2mp4.execute_ffmpeg")
     mock_execute_ffmpeg.return_value = FFmpegResult(stdout=b"", stderr="", returncode=0)
-    mock_get_mismatched_indices = mocker.patch(
-        "ts2mp4.ts2mp4.get_mismatched_audio_stream_indices", return_value=[]
+    mock_verify_audio_stream_integrity = mocker.patch(
+        "ts2mp4.ts2mp4.verify_audio_stream_integrity"
     )
 
     # Act
     ts2mp4(input_file, output_file, crf, preset)
 
     # Assert
-    mock_get_mismatched_indices.assert_called_once_with(
+    mock_verify_audio_stream_integrity.assert_called_once_with(
         input_file=input_file, output_file=output_file
     )
 
@@ -94,7 +94,7 @@ def test_ts2mp4_raises_runtime_error_on_ffmpeg_failure(mocker: MockerFixture) ->
     crf = 23
     preset = "medium"
 
-    mocker.patch("ts2mp4.ts2mp4.get_mismatched_audio_stream_indices")
+    mocker.patch("ts2mp4.ts2mp4.verify_audio_stream_integrity")
     mock_execute_ffmpeg = mocker.patch("ts2mp4.ts2mp4.execute_ffmpeg")
     mock_execute_ffmpeg.return_value = FFmpegResult(
         stdout=b"", stderr="ffmpeg error", returncode=1
@@ -106,7 +106,7 @@ def test_ts2mp4_raises_runtime_error_on_ffmpeg_failure(mocker: MockerFixture) ->
 
 
 @pytest.mark.unit
-def test_does_not_call_get_mismatched_indices_on_ffmpeg_failure(
+def test_does_not_call_verify_audio_stream_integrity_on_ffmpeg_failure(
     mocker: MockerFixture,
 ) -> None:
     """Test that ts2mp4 does not call verify_audio_stream_integrity on failure."""
@@ -117,8 +117,8 @@ def test_does_not_call_get_mismatched_indices_on_ffmpeg_failure(
     preset = "medium"
 
     mock_execute_ffmpeg = mocker.patch("ts2mp4.ts2mp4.execute_ffmpeg")
-    mock_get_mismatched_indices = mocker.patch(
-        "ts2mp4.ts2mp4.get_mismatched_audio_stream_indices"
+    mock_verify_audio_stream_integrity = mocker.patch(
+        "ts2mp4.ts2mp4.verify_audio_stream_integrity"
     )
     mock_execute_ffmpeg.return_value = FFmpegResult(
         stdout=b"", stderr="ffmpeg error", returncode=1
@@ -128,7 +128,7 @@ def test_does_not_call_get_mismatched_indices_on_ffmpeg_failure(
     with pytest.raises(RuntimeError):
         ts2mp4(input_file, output_file, crf, preset)
 
-    mock_get_mismatched_indices.assert_not_called()
+    mock_verify_audio_stream_integrity.assert_not_called()
 
 
 @pytest.mark.unit
@@ -144,13 +144,13 @@ def test_ts2mp4_raises_runtime_error_on_audio_integrity_failure(
     mock_execute_ffmpeg = mocker.patch("ts2mp4.ts2mp4.execute_ffmpeg")
     mock_execute_ffmpeg.return_value = FFmpegResult(stdout=b"", stderr="", returncode=0)
     mocker.patch(
-        "ts2mp4.ts2mp4.get_mismatched_audio_stream_indices",
-        return_value=[(0, 0), (2, 2)],
+        "ts2mp4.ts2mp4.verify_audio_stream_integrity",
+        side_effect=RuntimeError("Audio stream integrity check failed"),
     )
 
     # Act & Assert
     with pytest.raises(
         RuntimeError,
-        match=r"Audio stream integrity check failed for pairs: \[\(0, 0\), \(2, 2\)\]",
+        match="Audio stream integrity check failed",
     ):
         ts2mp4(input_file, output_file, crf, preset)

--- a/ts2mp4/ts2mp4.py
+++ b/ts2mp4/ts2mp4.py
@@ -1,6 +1,6 @@
 from pathlib import Path
 
-from .audio_integrity import get_mismatched_audio_stream_indices
+from .audio_integrity import verify_audio_stream_integrity
 from .ffmpeg import execute_ffmpeg
 
 
@@ -59,10 +59,4 @@ def ts2mp4(input_file: Path, output_file: Path, crf: int, preset: str) -> None:
     if result.returncode != 0:
         raise RuntimeError(f"ffmpeg failed with return code {result.returncode}")
 
-    mismatched_indices = get_mismatched_audio_stream_indices(
-        input_file=input_file, output_file=output_file
-    )
-    if mismatched_indices:
-        raise RuntimeError(
-            f"Audio stream integrity check failed for pairs: {mismatched_indices}"
-        )
+    verify_audio_stream_integrity(input_file=input_file, output_file=output_file)


### PR DESCRIPTION
This reverts the changes made to the audio stream integrity verification.

- Renames `get_mismatched_audio_stream_indices` back to `verify_audio_stream_integrity` in `ts2mp4/audio_integrity.py`.
- The `verify_audio_stream_integrity` function now raises a `RuntimeError` directly on failure.
- Updates `ts2mp4/ts2mp4.py` to call the reverted function.
- Adjusts tests in `tests/test_audio_integrity.py`, `tests/test_ts2mp4.py`, and `tests/test_media_info.py` to align with the reverted logic and pass the `make check` validation.