### PR TITLE
feat: Re-encode mismatched audio streams

### DIFF
--- a/ts2mp4/audio_integrity.py
+++ b/ts2mp4/audio_integrity.py
@@ -1,7 +1,9 @@
+import itertools
 from pathlib import Path
 
 from logzero import logger
 
+from .ffmpeg import execute_ffmpeg
 from .hashing import get_stream_md5
 from .media_info import Stream, get_media_info
 
@@ -41,6 +43,136 @@ def check_stream_integrity(
         return False
 
     return True
+
+
+def _build_args_for_audio_streams(original_file: Path, encoded_file: Path) -> list[str]:
+    """Builds the FFmpeg arguments for re-encoding mismatched audio streams.
+
+    It assumes that the order of audio streams is preserved between the original and encoded files.
+    """
+    original_media_info = get_media_info(original_file)
+    encoded_media_info = get_media_info(encoded_file)
+
+    original_audio_streams = [
+        stream for stream in original_media_info.streams if stream.codec_type == "audio"
+    ]
+    encoded_audio_streams = [
+        stream for stream in encoded_media_info.streams if stream.codec_type == "audio"
+    ]
+
+    args = []
+    for audio_stream_index, (original_audio_stream, encoded_audio_stream) in enumerate(
+        itertools.zip_longest(original_audio_streams, encoded_audio_streams)
+    ):
+        if original_audio_stream is None:
+            # Unexpected: Original file has fewer audio streams than expected.
+            raise RuntimeError(
+                f"Original file {original_file} has fewer audio streams than expected."
+            )
+
+        integrity_check_passes = False
+        if encoded_audio_stream is not None:
+            integrity_check_passes = check_stream_integrity(
+                input_file=original_file,
+                output_file=encoded_file,
+                input_stream=original_audio_stream,
+                output_stream=encoded_audio_stream,
+            )
+
+        if not integrity_check_passes:
+            if original_audio_stream.codec_name is None:
+                # Unexpected: Original file's audio stream lacks a codec name.
+                raise RuntimeError(
+                    f"Original audio stream at index {audio_stream_index} has no codec name."
+                )
+
+            logger.warning(
+                f"Re-encoding audio stream at index {audio_stream_index} "
+                f"from {original_file.name} due to mismatch or absence in {encoded_file.name}."
+            )
+
+            args.extend(
+                [
+                    "-map",
+                    f"0:a:{audio_stream_index}",  # Use original audio stream
+                    f"-codec:a:{audio_stream_index}",
+                    original_audio_stream.codec_name,  # Re-encode with original codec
+                    f"-bsf:a:{audio_stream_index}",
+                    "aac_adtstoasc",
+                ]
+            )
+        else:
+            args.extend(
+                [
+                    "-map",
+                    f"1:a:{audio_stream_index}",  # Use encoded audio stream
+                    f"-codec:a:{audio_stream_index}",
+                    "copy",  # Copy codec without re-encoding
+                ]
+            )
+
+    return args
+
+
+def re_encode_mismatched_audio_streams(
+    original_file: Path, encoded_file: Path, output_file: Path
+) -> None:
+    """Re-encodes mismatched audio streams from an original file to a new output file.
+
+    This function identifies audio streams that are either missing in the encoded
+    file or have different content compared to the original file. It then
+    generates a new video file by:
+    - Copying the video stream from the already encoded file.
+    - Copying matching audio streams from the encoded file.
+    - Re-encoding mismatched or missing audio streams from the original file
+      using their original codecs.
+    - Copying subtitle streams from the encoded file.
+
+    Args:
+    ----
+        original_file: The path to the original source file (e.g., .ts).
+        encoded_file: The path to the file that has been encoded but may have
+                      audio stream issues.
+        output_file: The path where the corrected output file will be saved.
+    """
+    args_for_audio_streams = _build_args_for_audio_streams(
+        original_file=original_file, encoded_file=encoded_file
+    )
+
+    if not args_for_audio_streams:
+        logger.info("No audio streams require re-encoding.")
+        return
+
+    ffmpeg_args = [
+        "-hide_banner",
+        "-nostats",
+        "-fflags",
+        "+discardcorrupt",
+        "-y",
+        "-i",
+        str(original_file),
+        "-i",
+        str(encoded_file),
+        # for video streams
+        "-map",
+        "1:v",  # Use video stream from encoded_file
+        "-codec:v",
+        "copy",  # Copy video codec without re-encoding
+        # for audio streams
+        *args_for_audio_streams,
+        # for subtitles
+        "-map",
+        "1:s?",  # Use subtitle streams from encoded_file if available
+        "-codec:s",
+        "copy",  # Copy subtitle codec without re-encoding
+        # output file
+        str(output_file),
+    ]
+
+    # Execute the FFmpeg command
+    result = execute_ffmpeg(ffmpeg_args)
+    if result.returncode != 0:
+        raise RuntimeError(f"ffmpeg failed with return code {result.returncode}")
 
 
 def verify_audio_stream_integrity(input_file: Path, output_file: Path) -> None:


### PR DESCRIPTION
Adds functionality to re-encode audio streams that fail an integrity check.

When `ts2mp4` is run, it now performs an integrity check on the audio streams of the output file. If the check fails (due to MD5 mismatch or a different number of streams), it will attempt to re-encode only the mismatched audio streams from the original file, copying the video and other audio streams.

This is handled by the new `re_encode_mismatched_audio_streams` function in `audio_integrity.py`, which is called from `ts2mp4.py` when `verify_audio_stream_integrity` raises a `RuntimeError`.

The following changes are included:
- Added `_build_args_for_audio_streams` to build FFmpeg arguments for re-encoding.
- Added `re_encode_mismatched_audio_streams` to perform the re-encoding.
- Added a docstring to `re_encode_mismatched_audio_streams`.
- Modified `ts2mp4` to catch `RuntimeError` from `verify_audio_stream_integrity` and trigger the re-encode process.
- Added unit tests for the new functions and the re-encoding logic.