### PR TITLE
feat: Add audio stream re-encoding on integrity failure

### DIFF
--- a/ts2mp4/audio_integrity.py
+++ b/ts2mp4/audio_integrity.py
@@ -67,7 +67,7 @@ def _build_args_for_audio_streams(original_file: Path, encoded_file: Path) -> li
         if original_audio_stream is None:
             # Unexpected: Original file has fewer audio streams than expected.
             raise RuntimeError(
-                f"Original file {original_file} has fewer audio streams than expected."
+                f"Encoded file {encoded_file.name} has more audio streams than the original {original_file.name}."
             )
 
         integrity_check_passes = False

--- a/ts2mp4/audio_integrity.py
+++ b/ts2mp4/audio_integrity.py
@@ -1,7 +1,9 @@
+import itertools
 from pathlib import Path
 
 from logzero import logger
 
+from .ffmpeg import execute_ffmpeg
 from .hashing import get_stream_md5
 from .media_info import Stream, get_media_info
 
@@ -41,6 +43,140 @@ def check_stream_integrity(
         return False
 
     return True
+
+
+def _build_args_for_audio_streams(original_file: Path, encoded_file: Path) -> list[str]:
+    """Builds the FFmpeg arguments for re-encoding mismatched audio streams.
+
+    It assumes that the order of audio streams is preserved between the original and encoded files.
+    """
+    original_media_info = get_media_info(original_file)
+    encoded_media_info = get_media_info(encoded_file)
+
+    original_audio_streams = [
+        stream for stream in original_media_info.streams if stream.codec_type == "audio"
+    ]
+    encoded_audio_streams = [
+        stream for stream in encoded_media_info.streams if stream.codec_type == "audio"
+    ]
+
+    args = []
+    for audio_stream_index, (original_audio_stream, encoded_audio_stream) in enumerate(
+        itertools.zip_longest(original_audio_streams, encoded_audio_streams)
+    ):
+        if original_audio_stream is None:
+            # Unexpected: Original file has fewer audio streams than expected.
+            raise RuntimeError(
+                f"Original file {original_file} has fewer audio streams than expected."
+            )
+
+        integrity_check_passes = False
+        if encoded_audio_stream is not None:
+            integrity_check_passes = check_stream_integrity(
+                input_file=original_file,
+                output_file=encoded_file,
+                input_stream=original_audio_stream,
+                output_stream=encoded_audio_stream,
+            )
+
+        if not integrity_check_passes:
+            if original_audio_stream.codec_name is None:
+                # Unexpected: Original file's audio stream lacks a codec name.
+                raise RuntimeError(
+                    f"Original audio stream at index {audio_stream_index} has no codec name."
+                )
+            if original_audio_stream.codec_name != "aac":
+                raise NotImplementedError(
+                    "Re-encoding is currently only supported for aac audio codec."
+                )
+
+            logger.warning(
+                f"Re-encoding audio stream at index {audio_stream_index} "
+                f"from {original_file.name} due to mismatch or absence in {encoded_file.name}."
+            )
+
+            args.extend(
+                [
+                    "-map",
+                    f"0:a:{audio_stream_index}",  # Use original audio stream
+                    f"-codec:a:{audio_stream_index}",
+                    original_audio_stream.codec_name,  # Re-encode with original codec
+                    f"-bsf:a:{audio_stream_index}",
+                    "aac_adtstoasc",
+                ]
+            )
+        else:
+            args.extend(
+                [
+                    "-map",
+                    f"1:a:{audio_stream_index}",  # Use encoded audio stream
+                    f"-codec:a:{audio_stream_index}",
+                    "copy",  # Copy codec without re-encoding
+                ]
+            )
+
+    return args
+
+
+def re_encode_mismatched_audio_streams(
+    original_file: Path, encoded_file: Path, output_file: Path
+) -> None:
+    """Re-encodes mismatched audio streams from an original file to a new output file.
+
+    This function identifies audio streams that are either missing in the encoded
+    file or have different content compared to the original file. It then
+    generates a new video file by:
+    - Copying the video stream from the already encoded file.
+    - Copying matching audio streams from the encoded file.
+    - Re-encoding mismatched or missing audio streams from the original file
+      using their original codecs.
+    - Copying subtitle streams from the encoded file.
+
+    Args:
+    ----
+        original_file: The path to the original source file (e.g., .ts).
+        encoded_file: The path to the file that has been encoded but may have
+                      audio stream issues.
+        output_file: The path where the corrected output file will be saved.
+    """
+    args_for_audio_streams = _build_args_for_audio_streams(
+        original_file=original_file, encoded_file=encoded_file
+    )
+
+    if not args_for_audio_streams:
+        logger.info("No audio streams require re-encoding.")
+        return
+
+    ffmpeg_args = [
+        "-hide_banner",
+        "-nostats",
+        "-fflags",
+        "+discardcorrupt",
+        "-y",
+        "-i",
+        str(original_file),
+        "-i",
+        str(encoded_file),
+        # for video streams
+        "-map",
+        "1:v",  # Use video stream from encoded_file
+        "-codec:v",
+        "copy",  # Copy video codec without re-encoding
+        # for audio streams
+        *args_for_audio_streams,
+        # for subtitles
+        "-map",
+        "1:s?",  # Use subtitle streams from encoded_file if available
+        "-codec:s",
+        "copy",  # Copy subtitle codec without re-encoding
+        # output file
+        str(output_file),
+    ]
+
+    # Execute the FFmpeg command
+    result = execute_ffmpeg(ffmpeg_args)
+    if result.returncode != 0:
+        raise RuntimeError(f"ffmpeg failed with return code {result.returncode}")
 
 
 def verify_audio_stream_integrity(input_file: Path, output_file: Path) -> None:

--- a/ts2mp4/ts2mp4.py
+++ b/ts2mp4/ts2mp4.py
@@ -1,6 +1,11 @@
 from pathlib import Path
 
-from .audio_integrity import verify_audio_stream_integrity
+from logzero import logger
+
+from .audio_integrity import (
+    re_encode_mismatched_audio_streams,
+    verify_audio_stream_integrity,
+)
 from .ffmpeg import execute_ffmpeg
 
 
@@ -59,4 +64,18 @@ def ts2mp4(input_file: Path, output_file: Path, crf: int, preset: str) -> None:
     if result.returncode != 0:
         raise RuntimeError(f"ffmpeg failed with return code {result.returncode}")
 
-    verify_audio_stream_integrity(input_file=input_file, output_file=output_file)
+    try:
+        verify_audio_stream_integrity(input_file=input_file, output_file=output_file)
+    except RuntimeError as e:
+        logger.warning(f"Audio integrity check failed: {e}")
+        logger.info("Attempting to re-encode mismatched audio streams.")
+        temp_output_file = output_file.with_suffix(output_file.suffix + ".temp")
+        re_encode_mismatched_audio_streams(
+            original_file=input_file,
+            encoded_file=output_file,
+            output_file=temp_output_file,
+        )
+        temp_output_file.replace(output_file)
+        logger.info(
+            f"Successfully re-encoded audio for {output_file.name} and replaced original."
+        )


### PR DESCRIPTION
Introduces a recovery mechanism for audio stream integrity failures. If `verify_audio_stream_integrity` fails, `ts2mp4` now attempts to re-encode only the mismatched audio streams.

- A `try...except` block is added in `ts2mp4.ts2mp4` to catch `RuntimeError` from `verify_audio_stream_integrity`.
- On failure, `re_encode_mismatched_audio_streams` is called to generate a corrected file.
- The temporary file is moved to the final destination using `Path.replace` for atomic operation.

The new function `re_encode_mismatched_audio_streams` in `ts2mp4.audio_integrity` orchestrates the re-encoding process. It uses `_build_args_for_audio_streams` to selectively copy or re-encode audio streams.

- Re-encoding is currently only implemented for the 'aac' codec; a `NotImplementedError` is raised for other codecs.

Unit and integration tests are added to cover the new functionality:
- `tests.test_ts2mp4` is updated to test the new error handling and recovery path.
- `tests.test_audio_integrity` includes new tests for `_build_args_for_audio_streams` and an integration test for the re-encoding process.