### PR TITLE
feat: Add function to check for libfdk_aac availability

### DIFF
--- a/ts2mp4/ffmpeg.py
+++ b/ts2mp4/ffmpeg.py
@@ -1,3 +1,4 @@
+import functools
 import subprocess
 from typing import Literal, NamedTuple
 
@@ -59,3 +60,16 @@ def execute_ffprobe(args: list[str]) -> FFmpegResult:
 
     """
     return _execute_process("ffprobe", args)
+
+
+@functools.cache
+def is_libfdk_aac_available() -> bool:
+    """Check if libfdk_aac is available in ffmpeg.
+
+    Returns
+    -------
+        True if libfdk_aac is available, False otherwise.
+
+    """
+    result = execute_ffmpeg(["-encoders"])
+    return b"libfdk_aac" in result.stdout


### PR DESCRIPTION
Adds a new function `is_libfdk_aac_available` to `ts2mp4/ffmpeg.py` to check if the libfdk_aac encoder is available in FFmpeg.

This is achieved by running `ffmpeg -encoders` and checking for the presence of "libfdk_aac" in the output.

Unit tests for this new function have been added to `tests/test_ffmpeg.py`, utilizing mocking to simulate the output of `ffmpeg -encoders`.