### PR TITLE
feat: Match audio properties on re-encode and refactor

### DIFF
--- a/tests/test_audio_integrity.py
+++ b/tests/test_audio_integrity.py
@@ -5,6 +5,7 @@ from pytest_mock import MockerFixture
 
 from ts2mp4.audio_integrity import (
     _build_args_for_audio_streams,
+    _build_re_encode_args,
     _verify_re_encoded_stream_integrity,
     check_stream_integrity,
     re_encode_mismatched_audio_streams,
@@ -12,6 +13,43 @@ from ts2mp4.audio_integrity import (
 )
 from ts2mp4.ffmpeg import execute_ffmpeg
 from ts2mp4.media_info import MediaInfo, Stream, get_media_info
+
+
+@pytest.mark.unit
+def test_build_re_encode_args() -> None:
+    stream = Stream(
+        index=1,
+        codec_name="aac",
+        codec_type="audio",
+        sample_rate=48000,
+        channels=2,
+        profile="LC",
+        bit_rate=192000,
+    )
+    args = _build_re_encode_args(1, stream)
+    assert args == [
+        "-map",
+        "0:a:1",
+        "-codec:a:1",
+        "aac",
+        "-ar:a:1",
+        "48000",
+        "-ac:a:1",
+        "2",
+        "-profile:a:1",
+        "aac_low",
+        "-b:a:1",
+        "192000",
+        "-bsf:a:1",
+        "aac_adtstoasc",
+    ]
+
+
+@pytest.mark.unit
+def test_build_re_encode_args_with_none_values() -> None:
+    stream = Stream(index=1, codec_name="aac", codec_type="audio")
+    args = _build_re_encode_args(1, stream)
+    assert args == ["-map", "0:a:1", "-codec:a:1", "aac", "-bsf:a:1", "aac_adtstoasc"]
 
 
 @pytest.mark.unit


### PR DESCRIPTION
- I've added logic to match the sample rate, channels, profile, and bit rate of the original audio stream when re-encoding.
- I've also mapped the 'LC' profile to 'aac_low' for ffmpeg compatibility.
- I refactored the re-encoding argument construction into a helper function `_build_re_encode_args`.
- Finally, I added unit tests for the new helper function.