### PR TITLE
refactor: Improve clarity of stream integrity function names

### DIFF
--- a/tests/test_audio_integrity.py
+++ b/tests/test_audio_integrity.py
@@ -23,7 +23,7 @@ def test_build_args_for_audio_streams_no_mismatch(mocker: MockerFixture) -> None
             ]
         ),
     )
-    mocker.patch("ts2mp4.audio_integrity.check_stream_integrity", return_value=True)
+    mocker.patch("ts2mp4.audio_integrity.compare_stream_hashes", return_value=True)
 
     result = _build_args_for_audio_streams(Path("original.ts"), Path("encoded.mp4"))
     assert result.ffmpeg_args == [
@@ -60,7 +60,7 @@ def test_build_args_for_audio_streams_with_mismatch(mocker: MockerFixture) -> No
         ],
     )
     mocker.patch(
-        "ts2mp4.audio_integrity.check_stream_integrity", side_effect=[True, False]
+        "ts2mp4.audio_integrity.compare_stream_hashes", side_effect=[True, False]
     )
 
     result = _build_args_for_audio_streams(Path("original.ts"), Path("encoded.mp4"))
@@ -99,7 +99,7 @@ def test_build_args_for_audio_streams_unsupported_codec(
             ),
         ],
     )
-    mocker.patch("ts2mp4.audio_integrity.check_stream_integrity", return_value=False)
+    mocker.patch("ts2mp4.audio_integrity.compare_stream_hashes", return_value=False)
 
     with pytest.raises(NotImplementedError):
         _build_args_for_audio_streams(Path("original.ts"), Path("encoded.mp4"))

--- a/tests/test_ts2mp4.py
+++ b/tests/test_ts2mp4.py
@@ -18,7 +18,7 @@ def test_calls_execute_ffmpeg_with_correct_args(mocker: MockerFixture) -> None:
 
     mock_execute_ffmpeg = mocker.patch("ts2mp4.ts2mp4.execute_ffmpeg")
     mock_execute_ffmpeg.return_value = FFmpegResult(stdout=b"", stderr="", returncode=0)
-    mocker.patch("ts2mp4.ts2mp4.verify_stream_integrity")
+    mocker.patch("ts2mp4.ts2mp4.verify_streams")
 
     # Act
     ts2mp4(input_file, output_file, crf, preset)
@@ -62,7 +62,7 @@ def test_calls_execute_ffmpeg_with_correct_args(mocker: MockerFixture) -> None:
 
 
 @pytest.mark.unit
-def test_calls_verify_stream_integrity_on_success(mocker: MockerFixture) -> None:
+def test_calls_verify_streams_on_success(mocker: MockerFixture) -> None:
     # Arrange
     input_file = Path("input.ts")
     output_file = Path("output.mp4")
@@ -71,13 +71,13 @@ def test_calls_verify_stream_integrity_on_success(mocker: MockerFixture) -> None
 
     mock_execute_ffmpeg = mocker.patch("ts2mp4.ts2mp4.execute_ffmpeg")
     mock_execute_ffmpeg.return_value = FFmpegResult(stdout=b"", stderr="", returncode=0)
-    mock_verify_stream_integrity = mocker.patch("ts2mp4.ts2mp4.verify_stream_integrity")
+    mock_verify_streams = mocker.patch("ts2mp4.ts2mp4.verify_streams")
 
     # Act
     ts2mp4(input_file, output_file, crf, preset)
 
     # Assert
-    mock_verify_stream_integrity.assert_called_once_with(
+    mock_verify_streams.assert_called_once_with(
         input_file=input_file, output_file=output_file, stream_type="audio"
     )
 
@@ -90,7 +90,7 @@ def test_ts2mp4_raises_runtime_error_on_ffmpeg_failure(mocker: MockerFixture) ->
     crf = 23
     preset = "medium"
 
-    mocker.patch("ts2mp4.ts2mp4.verify_stream_integrity")
+    mocker.patch("ts2mp4.ts2mp4.verify_streams")
     mock_execute_ffmpeg = mocker.patch("ts2mp4.ts2mp4.execute_ffmpeg")
     mock_execute_ffmpeg.return_value = FFmpegResult(
         stdout=b"", stderr="ffmpeg error", returncode=1
@@ -102,10 +102,10 @@ def test_ts2mp4_raises_runtime_error_on_ffmpeg_failure(mocker: MockerFixture) ->
 
 
 @pytest.mark.unit
-def test_does_not_call_verify_stream_integrity_on_ffmpeg_failure(
+def test_does_not_call_verify_streams_on_ffmpeg_failure(
     mocker: MockerFixture,
 ) -> None:
-    """Test that ts2mp4 does not call verify_stream_integrity on failure."""
+    """Test that ts2mp4 does not call verify_streams on failure."""
     # Arrange
     input_file = Path("input.ts")
     output_file = Path("output.mp4")
@@ -113,7 +113,7 @@ def test_does_not_call_verify_stream_integrity_on_ffmpeg_failure(
     preset = "medium"
 
     mock_execute_ffmpeg = mocker.patch("ts2mp4.ts2mp4.execute_ffmpeg")
-    mock_verify_stream_integrity = mocker.patch("ts2mp4.ts2mp4.verify_stream_integrity")
+    mock_verify_streams = mocker.patch("ts2mp4.ts2mp4.verify_streams")
     mock_execute_ffmpeg.return_value = FFmpegResult(
         stdout=b"", stderr="ffmpeg error", returncode=1
     )
@@ -122,7 +122,7 @@ def test_does_not_call_verify_stream_integrity_on_ffmpeg_failure(
     with pytest.raises(RuntimeError):
         ts2mp4(input_file, output_file, crf, preset)
 
-    mock_verify_stream_integrity.assert_not_called()
+    mock_verify_streams.assert_not_called()
 
 
 @pytest.mark.unit
@@ -138,7 +138,7 @@ def test_ts2mp4_re_encodes_on_stream_integrity_failure(mocker: MockerFixture) ->
         return_value=FFmpegResult(stdout=b"", stderr="", returncode=0),
     )
     mocker.patch(
-        "ts2mp4.ts2mp4.verify_stream_integrity",
+        "ts2mp4.ts2mp4.verify_streams",
         side_effect=RuntimeError("Audio stream integrity check failed"),
     )
     mock_re_encode = mocker.patch("ts2mp4.ts2mp4.re_encode_mismatched_audio_streams")
@@ -168,7 +168,7 @@ def test_ts2mp4_re_encode_failure_raises_error(mocker: MockerFixture) -> None:
         return_value=FFmpegResult(stdout=b"", stderr="", returncode=0),
     )
     mocker.patch(
-        "ts2mp4.ts2mp4.verify_stream_integrity",
+        "ts2mp4.ts2mp4.verify_streams",
         side_effect=RuntimeError("Audio stream integrity check failed"),
     )
     mocker.patch(

--- a/ts2mp4/audio_integrity.py
+++ b/ts2mp4/audio_integrity.py
@@ -6,7 +6,7 @@ from logzero import logger
 
 from .ffmpeg import execute_ffmpeg
 from .media_info import get_media_info
-from .stream_integrity import check_stream_integrity, verify_stream_integrity
+from .stream_integrity import compare_stream_hashes, verify_streams
 
 
 class AudioStreamArgs(NamedTuple):
@@ -47,7 +47,7 @@ def _build_args_for_audio_streams(
 
         integrity_check_passes = False
         if encoded_audio_stream is not None:
-            integrity_check_passes = check_stream_integrity(
+            integrity_check_passes = compare_stream_hashes(
                 input_file=original_file,
                 output_file=encoded_file,
                 input_stream=original_audio_stream,
@@ -125,8 +125,8 @@ def re_encode_mismatched_audio_streams(
         """Verifies the integrity of streams after re-encoding."""
         logger.info(f"Verifying stream integrity for {output_file.name}")
 
-        verify_stream_integrity(encoded_file, output_file, "video")
-        verify_stream_integrity(
+        verify_streams(encoded_file, output_file, "video")
+        verify_streams(
             encoded_file,
             output_file,
             "audio",

--- a/ts2mp4/stream_integrity.py
+++ b/ts2mp4/stream_integrity.py
@@ -7,7 +7,7 @@ from .hashing import get_stream_md5
 from .media_info import Stream, get_media_info
 
 
-def check_stream_integrity(
+def compare_stream_hashes(
     input_file: Path,
     output_file: Path,
     input_stream: "Stream",
@@ -44,7 +44,7 @@ def check_stream_integrity(
     return True
 
 
-def verify_stream_integrity(
+def verify_streams(
     input_file: Path,
     output_file: Path,
     stream_type: str,
@@ -89,7 +89,7 @@ def verify_stream_integrity(
         )
 
     for input_stream, output_stream in zip(input_streams, output_streams):
-        if not check_stream_integrity(
+        if not compare_stream_hashes(
             input_file, output_file, input_stream, output_stream
         ):
             raise RuntimeError(

--- a/ts2mp4/ts2mp4.py
+++ b/ts2mp4/ts2mp4.py
@@ -4,7 +4,7 @@ from logzero import logger
 
 from .audio_integrity import re_encode_mismatched_audio_streams
 from .ffmpeg import execute_ffmpeg
-from .stream_integrity import verify_stream_integrity
+from .stream_integrity import verify_streams
 
 
 def ts2mp4(input_file: Path, output_file: Path, crf: int, preset: str) -> None:
@@ -63,7 +63,7 @@ def ts2mp4(input_file: Path, output_file: Path, crf: int, preset: str) -> None:
         raise RuntimeError(f"ffmpeg failed with return code {result.returncode}")
 
     try:
-        verify_stream_integrity(
+        verify_streams(
             input_file=input_file, output_file=output_file, stream_type="audio"
         )
     except RuntimeError as e:


### PR DESCRIPTION
Renamed the stream integrity functions to be more descriptive and less ambiguous.

- `check_stream_integrity` is now `compare_stream_hashes`
- `verify_stream_integrity` is now `verify_streams`

This change clarifies whether a function is comparing hashes of a single stream or verifying multiple streams, improving code readability.