### PR TITLE
feat: Use poetry to get project version in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -61,7 +61,7 @@ release:
 		exit 1; \
 	fi
 	@echo "Getting version from pyproject.toml..."
-	$(eval VERSION := $(shell sed -n 's/version = \"\(.*\)\"/\1/p' pyproject.toml))
+	$(eval VERSION := $(shell poetry version --short))
 	@echo "Version: $(VERSION)"
 	@echo "Creating git tag $(VERSION)..."
 	git tag $(VERSION)


### PR DESCRIPTION
This commit updates the Makefile to use `poetry version --short` instead of a `sed` command to extract the project version. This change makes the release process more robust and less prone to breaking on formatting changes in `pyproject.toml`.