### PR TITLE
feat: Enable pydocstyle and fix violations

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,7 +49,7 @@ select = [
   "W",  # pycodestyle warnings
   "F",  # pyflakes
   "I",  # isort
-  # "D",  # pydocstyle - Temporarily disabled
+  "D",  # pydocstyle
 ]
 ignore = ["E501"]
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,3 +1,5 @@
+"""Pytest configuration file."""
+
 from pathlib import Path
 
 import pytest

--- a/tests/test_audio_reencoder.py
+++ b/tests/test_audio_reencoder.py
@@ -1,3 +1,5 @@
+"""Unit and integration tests for the audio_reencoder module."""
+
 from pathlib import Path
 
 import pytest
@@ -14,6 +16,7 @@ from ts2mp4.media_info import MediaInfo, Stream, get_media_info
 
 @pytest.mark.unit
 def test_build_re_encode_args(mocker: MockerFixture) -> None:
+    """Test that re-encode arguments are built correctly."""
     mocker.patch("ts2mp4.audio_reencoder.is_libfdk_aac_available", return_value=False)
     stream = Stream(
         index=1,
@@ -45,6 +48,7 @@ def test_build_re_encode_args(mocker: MockerFixture) -> None:
 
 @pytest.mark.unit
 def test_build_re_encode_args_with_libfdk_aac(mocker: MockerFixture) -> None:
+    """Test that libfdk_aac is used when available."""
     mocker.patch("ts2mp4.audio_reencoder.is_libfdk_aac_available", return_value=True)
     stream = Stream(
         index=1,
@@ -57,6 +61,7 @@ def test_build_re_encode_args_with_libfdk_aac(mocker: MockerFixture) -> None:
 
 @pytest.mark.unit
 def test_build_re_encode_args_without_libfdk_aac(mocker: MockerFixture) -> None:
+    """Test that a warning is logged when libfdk_aac is not available."""
     mocker.patch("ts2mp4.audio_reencoder.is_libfdk_aac_available", return_value=False)
     mock_logger_warning = mocker.patch("ts2mp4.audio_reencoder.logger.warning")
     stream = Stream(
@@ -73,6 +78,7 @@ def test_build_re_encode_args_without_libfdk_aac(mocker: MockerFixture) -> None:
 
 @pytest.mark.unit
 def test_build_re_encode_args_with_none_values() -> None:
+    """Test that re-encode arguments are built correctly with minimal stream info."""
     stream = Stream(index=1, codec_name="aac", codec_type="audio")
     args = _build_re_encode_args(1, stream)
     assert args == ["-map", "0:a:1", "-codec:a:1", "aac", "-bsf:a:1", "aac_adtstoasc"]

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,3 +1,5 @@
+"""Unit and integration tests for the CLI."""
+
 import subprocess
 from pathlib import Path
 

--- a/tests/test_e2e.py
+++ b/tests/test_e2e.py
@@ -1,3 +1,5 @@
+"""End-to-end tests for the ts2mp4 package."""
+
 import subprocess
 from collections.abc import Generator
 from pathlib import Path

--- a/tests/test_ffmpeg.py
+++ b/tests/test_ffmpeg.py
@@ -1,3 +1,5 @@
+"""Unit and integration tests for the ffmpeg module."""
+
 import io
 import logging
 from unittest.mock import MagicMock

--- a/tests/test_hashing.py
+++ b/tests/test_hashing.py
@@ -1,3 +1,5 @@
+"""Unit and integration tests for the hashing module."""
+
 from pathlib import Path
 
 import pytest
@@ -10,7 +12,7 @@ from ts2mp4.media_info import Stream
 
 @pytest.fixture(autouse=True)
 def _clear_hashing_cache() -> None:
-    """A fixture to automatically clear the cache for get_stream_md5 before each test."""
+    """Clear the cache for get_stream_md5 before each test."""
     _get_stream_md5_cached.cache_clear()
 
 

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -1,3 +1,5 @@
+"""Unit tests for the __init__ module."""
+
 import importlib.metadata
 
 import pytest

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -1,3 +1,5 @@
+"""End-to-end tests for the logging functionality."""
+
 import subprocess
 from pathlib import Path
 

--- a/tests/test_media_info.py
+++ b/tests/test_media_info.py
@@ -1,3 +1,5 @@
+"""Unit and integration tests for the media_info module."""
+
 import json
 from pathlib import Path
 from unittest.mock import MagicMock
@@ -21,6 +23,7 @@ def _clear_cache() -> None:
 
 @pytest.fixture()
 def mock_path() -> MagicMock:
+    """Return a mock Path object."""
     mock = MagicMock(spec=Path)
     mock.resolve.return_value = mock
     mock.stat.return_value = MagicMock(st_mtime=123.45, st_size=67890)

--- a/tests/test_quality_check.py
+++ b/tests/test_quality_check.py
@@ -1,3 +1,5 @@
+"""Unit and integration tests for the quality_check module."""
+
 from pathlib import Path
 from typing import Union
 
@@ -62,6 +64,7 @@ def test_parse_audio_quality_metrics(
     expected_apsnr: Union[float, None],
     expected_asdr: Union[float, None],
 ) -> None:
+    """Test parsing of audio quality metrics from FFmpeg output."""
     metrics = parse_audio_quality_metrics(ffmpeg_output)
     assert metrics.apsnr == expected_apsnr
     assert metrics.asdr == expected_asdr
@@ -90,6 +93,7 @@ def test_get_audio_quality_metrics_unit(
     ffmpeg_stderr: str,
     expected_metrics: Union[AudioQualityMetrics, None],
 ) -> None:
+    """Test the audio quality metrics calculation unit."""
     mock_execute_ffmpeg = mocker.patch("ts2mp4.quality_check.execute_ffmpeg")
     mock_execute_ffmpeg.return_value.returncode = 0 if expected_metrics else 1
     mock_execute_ffmpeg.return_value.stderr = ffmpeg_stderr

--- a/tests/test_stream_integrity.py
+++ b/tests/test_stream_integrity.py
@@ -1,3 +1,5 @@
+"""Unit tests for the stream_integrity module."""
+
 from pathlib import Path
 
 import pytest

--- a/tests/test_ts2mp4.py
+++ b/tests/test_ts2mp4.py
@@ -1,3 +1,5 @@
+"""Unit tests for the ts2mp4 module."""
+
 from pathlib import Path
 
 import pytest
@@ -63,6 +65,7 @@ def test_calls_execute_ffmpeg_with_correct_args(mocker: MockerFixture) -> None:
 
 @pytest.mark.unit
 def test_calls_verify_streams_on_success(mocker: MockerFixture) -> None:
+    """Test that verify_streams is called on successful conversion."""
     # Arrange
     input_file = Path("input.ts")
     output_file = Path("output.mp4")
@@ -84,6 +87,7 @@ def test_calls_verify_streams_on_success(mocker: MockerFixture) -> None:
 
 @pytest.mark.unit
 def test_ts2mp4_raises_runtime_error_on_ffmpeg_failure(mocker: MockerFixture) -> None:
+    """Test that a RuntimeError is raised on ffmpeg failure."""
     # Arrange
     input_file = Path("input.ts")
     output_file = Path("output.mp4")
@@ -127,6 +131,7 @@ def test_does_not_call_verify_streams_on_ffmpeg_failure(
 
 @pytest.mark.unit
 def test_ts2mp4_re_encodes_on_stream_integrity_failure(mocker: MockerFixture) -> None:
+    """Test that re-encoding is triggered on stream integrity failure."""
     # Arrange
     input_file = Path("input.ts")
     output_file = Path("output.mp4")
@@ -157,6 +162,7 @@ def test_ts2mp4_re_encodes_on_stream_integrity_failure(mocker: MockerFixture) ->
 
 @pytest.mark.unit
 def test_ts2mp4_re_encode_failure_raises_error(mocker: MockerFixture) -> None:
+    """Test that a RuntimeError is raised on re-encode failure."""
     # Arrange
     input_file = Path("input.ts")
     output_file = Path("output.mp4")

--- a/ts2mp4/__init__.py
+++ b/ts2mp4/__init__.py
@@ -1,3 +1,5 @@
+"""A tool for converting TS video files to MP4 format."""
+
 import importlib.metadata
 
 

--- a/ts2mp4/__main__.py
+++ b/ts2mp4/__main__.py
@@ -1,3 +1,5 @@
+"""Allow the package to be run as a script."""
+
 from ts2mp4.cli import app
 
 if __name__ == "__main__":

--- a/ts2mp4/audio_reencoder.py
+++ b/ts2mp4/audio_reencoder.py
@@ -1,3 +1,5 @@
+"""Re-encodes audio streams that have integrity issues."""
+
 import itertools
 from pathlib import Path
 from typing import NamedTuple
@@ -75,7 +77,7 @@ def _build_re_encode_args(
 def _build_args_for_audio_streams(
     original_file: Path, encoded_file: Path
 ) -> AudioStreamArgs:
-    """Builds FFmpeg arguments and identifies copied audio streams.
+    """Build FFmpeg arguments and identify copied audio streams.
 
     It assumes that the order of audio streams is preserved between the
     original and encoded files.
@@ -161,7 +163,6 @@ def re_encode_mismatched_audio_streams(
     - Copying matching audio streams from the encoded file.
     - Re-encoding mismatched or missing audio streams from the original file
       using their original codecs.
-    - Copying subtitle streams from the encoded file.
 
     Args:
     ----
@@ -174,7 +175,7 @@ def re_encode_mismatched_audio_streams(
     def _verify_integrity(
         copied_audio_stream_indices: list[int],
     ) -> None:
-        """Verifies the integrity of streams after re-encoding."""
+        """Verify the integrity of streams after re-encoding."""
         logger.info(f"Verifying stream integrity for {output_file.name}")
 
         verify_streams(encoded_file, output_file, "video")

--- a/ts2mp4/cli.py
+++ b/ts2mp4/cli.py
@@ -1,3 +1,5 @@
+"""Command-line interface for ts2mp4."""
+
 import datetime
 import platform
 from enum import Enum

--- a/ts2mp4/ffmpeg.py
+++ b/ts2mp4/ffmpeg.py
@@ -1,3 +1,5 @@
+"""A module for interacting with FFmpeg."""
+
 import functools
 import subprocess
 from typing import Literal, NamedTuple
@@ -39,7 +41,7 @@ def execute_ffmpeg(args: list[str]) -> FFmpegResult:
     ----
         args: A list of arguments for the command.
 
-    Returns:
+    Returns
     -------
         An FFmpegResult object with the command's results.
 
@@ -54,7 +56,7 @@ def execute_ffprobe(args: list[str]) -> FFmpegResult:
     ----
         args: A list of arguments for the command.
 
-    Returns:
+    Returns
     -------
         An FFmpegResult object with the command's results.
 

--- a/ts2mp4/hashing.py
+++ b/ts2mp4/hashing.py
@@ -1,3 +1,5 @@
+"""A module for calculating stream hashes."""
+
 import hashlib
 from functools import cache
 from pathlib import Path
@@ -48,11 +50,11 @@ def get_stream_md5(file_path: Path, stream: Stream) -> str:
         file_path: The path to the input file.
         stream: The stream object to process.
 
-    Returns:
+    Returns
     -------
         The MD5 hash of the decoded stream as a hexadecimal string.
 
-    Raises:
+    Raises
     ------
         ValueError: If the stream type is unsupported.
         RuntimeError: If ffmpeg fails to extract the stream.

--- a/ts2mp4/media_info.py
+++ b/ts2mp4/media_info.py
@@ -1,3 +1,5 @@
+"""A module for getting media information."""
+
 import json
 from functools import cache
 from pathlib import Path
@@ -31,6 +33,8 @@ class Format(BaseModel):
 
 
 class MediaInfo(BaseModel):
+    """A class to hold media information."""
+
     model_config = ConfigDict(frozen=True)
 
     streams: tuple[Stream, ...] = Field(default_factory=tuple)
@@ -60,17 +64,17 @@ def _get_media_info_cached(file_path: Path, _mtime: float, _size: int) -> MediaI
 
 
 def get_media_info(file_path: Path) -> MediaInfo:
-    """Returns media information for a given file.
+    """Return media information for a given file.
 
     Args:
     ----
         file_path: The path to the input file.
 
-    Returns:
+    Returns
     -------
         A MediaInfo object with the media information.
 
-    Raises:
+    Raises
     ------
         RuntimeError: If ffprobe fails to get media information.
 

--- a/ts2mp4/quality_check.py
+++ b/ts2mp4/quality_check.py
@@ -1,3 +1,5 @@
+"""A module for checking the quality of audio streams."""
+
 import re
 from pathlib import Path
 from typing import NamedTuple, Optional
@@ -8,12 +10,14 @@ from .ffmpeg import execute_ffmpeg
 
 
 class AudioQualityMetrics(NamedTuple):
+    """A class to hold audio quality metrics."""
+
     apsnr: Optional[float]  # Average Peak Signal-to-Noise Ratio
     asdr: Optional[float]  # Average Signal-to-Distortion Ratio
 
 
 def parse_audio_quality_metrics(output: str) -> AudioQualityMetrics:
-    """Parses FFmpeg output and logs APSNR and ASDR metrics."""
+    """Parse FFmpeg output and log APSNR and ASDR metrics."""
     apsnr = None
     asdr = None
 
@@ -52,7 +56,7 @@ def get_audio_quality_metrics(
     re_encoded_file: Path,
     audio_stream_index: int,
 ) -> Optional[AudioQualityMetrics]:
-    """Calculates APSNR and ASDR for an audio stream using FFmpeg.
+    """Calculate APSNR and ASDR for an audio stream using FFmpeg.
 
     Args:
     ----
@@ -60,7 +64,7 @@ def get_audio_quality_metrics(
         re_encoded_file: Path to the re-encoded file.
         audio_stream_index: The index of the audio stream to analyze.
 
-    Returns:
+    Returns
     -------
         An AudioQualityMetrics namedtuple containing apsnr and asdr, or None if metrics could not be calculated.
     """

--- a/ts2mp4/stream_integrity.py
+++ b/ts2mp4/stream_integrity.py
@@ -1,3 +1,5 @@
+"""A module for verifying stream integrity."""
+
 from pathlib import Path
 from typing import Optional
 
@@ -13,9 +15,10 @@ def compare_stream_hashes(
     input_stream: "Stream",
     output_stream: "Stream",
 ) -> bool:
-    """Checks the integrity of a single stream by comparing MD5 hashes.
+    """Check the integrity of a single stream by comparing MD5 hashes.
 
-    Returns:
+    Returns
+    -------
         True if the stream hashes match and hash generation is successful, False otherwise.
     """
     try:
@@ -50,7 +53,7 @@ def verify_streams(
     stream_type: str,
     type_specific_stream_indices: Optional[list[int]] = None,
 ) -> None:
-    """Verifies the integrity of specified streams by comparing their MD5 hashes.
+    """Verify the integrity of specified streams by comparing their MD5 hashes.
 
     Args:
     ----
@@ -61,7 +64,7 @@ def verify_streams(
                                      If None, all streams of the specified
                                      type are checked.
 
-    Raises:
+    Raises
     ------
         RuntimeError: If there's a mismatch in stream counts or if any
             stream's MD5 hash does not match.

--- a/ts2mp4/ts2mp4.py
+++ b/ts2mp4/ts2mp4.py
@@ -1,3 +1,5 @@
+"""The main module of the ts2mp4 package."""
+
 from pathlib import Path
 
 from logzero import logger
@@ -8,11 +10,12 @@ from .stream_integrity import verify_streams
 
 
 def ts2mp4(input_file: Path, output_file: Path, crf: int, preset: str) -> None:
-    """Converts a Transport Stream (TS) file to MP4 format using FFmpeg.
+    """Convert a Transport Stream (TS) file to MP4 format using FFmpeg.
 
     This function constructs and executes an FFmpeg command to perform the video
     conversion. It also logs the FFmpeg output and verifies the audio stream
-    integrity of the converted file.
+    integrity of the converted file. If the audio stream integrity check fails,
+    it attempts to re-encode the mismatched audio streams.
 
     Args:
     ----


### PR DESCRIPTION
I've enabled pydocstyle checks and fixed all related violations.

Key changes:
- enabled pydocstyle ('D') in `pyproject.toml`.
- added/updated docstrings for all modules, classes, and functions.
- ensured docstrings conform to the numpy style guide.
- updated outdated docstrings to reflect the current implementation.