### PR TITLE
fix(audio): Explicitly specify mp4 format for FFmpeg re-encoding

### DIFF
--- a/ts2mp4/audio_reencoder.py
+++ b/ts2mp4/audio_reencoder.py
@@ -218,6 +218,8 @@ def re_encode_mismatched_audio_streams(
         # "-codec:s",
         # "copy",  # Copy subtitle codec without re-encoding
         # output file
+        "-f",
+        "mp4",
         str(output_file),
     ]
 


### PR DESCRIPTION
The FFmpeg command for re-encoding audio streams was failing because it could not determine the output format from the temporary filename. This change adds the `-f mp4` flag to the FFmpeg command to explicitly specify the output format, which resolves the issue.