### PR TITLE
fix: Squelch ffmpeg progress in hashing

### DIFF
--- a/ts2mp4/hashing.py
+++ b/ts2mp4/hashing.py
@@ -23,6 +23,7 @@ def _get_stream_md5_cached(
 
     ffmpeg_args = [
         "-hide_banner",
+        "-nostats",
         "-i",
         str(file_path),
         "-map",


### PR DESCRIPTION
Adds the `-nostats` flag to the ffmpeg command in `ts2mp4/hashing.py`. This suppresses the progress indicator that was appearing in the logs during the stream hashing process, which is unnecessary for you to see.