### PR TITLE
Refactor: Change _execute_process to a generator

### DIFF
--- a/ts2mp4/ffmpeg.py
+++ b/ts2mp4/ffmpeg.py
@@ -2,7 +2,7 @@
 
 import functools
 import subprocess
-from typing import Literal, NamedTuple
+from typing import Generator, Literal, NamedTuple
 
 from logzero import logger
 
@@ -17,12 +17,20 @@ class FFmpegResult(NamedTuple):
 
 def _execute_process(
     executable: Literal["ffmpeg", "ffprobe"], args: list[str]
-) -> FFmpegResult:
+) -> Generator[bytes, None, tuple[int, str]]:
     command = [executable] + args
     logger.info(f"Running command: {' '.join(command)}")
 
     process = subprocess.Popen(command, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-    stdout, stderr_bytes = process.communicate()
+
+    if process.stdout is None or process.stderr is None:
+        # This should not happen, as stdout and stderr are piped.
+        raise RuntimeError("Failed to open stdout/stderr for the process.")
+
+    while chunk := process.stdout.read(1024):
+        yield chunk
+
+    stderr_bytes = process.stderr.read()
 
     # stdout is treated as binary data, as it can contain multimedia streams.
     # stderr is treated as text, as it's used for logs and progress information.
@@ -31,7 +39,8 @@ def _execute_process(
     if stderr:
         logger.info(stderr)
 
-    return FFmpegResult(stdout=stdout, stderr=stderr, returncode=process.returncode)
+    process.wait()
+    return process.returncode, stderr
 
 
 def execute_ffmpeg(args: list[str]) -> FFmpegResult:
@@ -46,7 +55,15 @@ def execute_ffmpeg(args: list[str]) -> FFmpegResult:
         An FFmpegResult object with the command's results.
 
     """
-    return _execute_process("ffmpeg", args)
+    process_generator = _execute_process("ffmpeg", args)
+    stdout_chunks = []
+    try:
+        while True:
+            stdout_chunks.append(next(process_generator))
+    except StopIteration as e:
+        returncode, stderr = e.value
+    stdout = b"".join(stdout_chunks)
+    return FFmpegResult(stdout=stdout, stderr=stderr, returncode=returncode)
 
 
 def execute_ffprobe(args: list[str]) -> FFmpegResult:
@@ -61,7 +78,15 @@ def execute_ffprobe(args: list[str]) -> FFmpegResult:
         An FFmpegResult object with the command's results.
 
     """
-    return _execute_process("ffprobe", args)
+    process_generator = _execute_process("ffprobe", args)
+    stdout_chunks = []
+    try:
+        while True:
+            stdout_chunks.append(next(process_generator))
+    except StopIteration as e:
+        returncode, stderr = e.value
+    stdout = b"".join(stdout_chunks)
+    return FFmpegResult(stdout=stdout, stderr=stderr, returncode=returncode)
 
 
 @functools.cache


### PR DESCRIPTION
This commit refactors the `_execute_process` function to be a generator that yields stdout and returns the returncode and stderr. The behavior of `execute_ffmpeg` and `execute_ffprobe` remains unchanged.