### PR TITLE
feat(ts2mp4): Filter invalid audio streams and improve ffmpeg arg construction

### DIFF
--- a/tests/test_ts2mp4.py
+++ b/tests/test_ts2mp4.py
@@ -1,16 +1,35 @@
 """Unit tests for the ts2mp4 module."""
 
 from pathlib import Path
+from unittest.mock import MagicMock
 
 import pytest
 from pytest_mock import MockerFixture
 
 from ts2mp4.ffmpeg import FFmpegResult
+from ts2mp4.media_info import MediaInfo, Stream
 from ts2mp4.ts2mp4 import ts2mp4
 
 
+@pytest.fixture
+def mock_get_media_info(mocker: MockerFixture) -> MagicMock:
+    """Mock get_media_info to return a standard MediaInfo object."""
+    mock = mocker.patch("ts2mp4.ts2mp4.get_media_info")
+    mock.return_value = MediaInfo(
+        streams=(
+            Stream(codec_type="video", index=0),
+            Stream(codec_type="audio", index=1, channels=2),
+            Stream(codec_type="audio", index=2, channels=0),  # Invalid stream
+            Stream(codec_type="audio", index=3, channels=6),
+        )
+    )
+    return mock
+
+
 @pytest.mark.unit
-def test_calls_execute_ffmpeg_with_correct_args(mocker: MockerFixture) -> None:
+def test_calls_execute_ffmpeg_with_correct_args(
+    mocker: MockerFixture, mock_get_media_info: MagicMock
+) -> None:
     """Test that ts2mp4 calls execute_ffmpeg with the correct arguments."""
     # Arrange
     input_file = Path("input.ts")
@@ -37,9 +56,9 @@ def test_calls_execute_ffmpeg_with_correct_args(mocker: MockerFixture) -> None:
         "-map",
         "0:v",
         "-map",
-        "0:a",
-        # "-map",
-        # "0:s?",
+        "0:1",
+        "-map",
+        "0:3",
         "-f",
         "mp4",
         "-vsync",
@@ -54,17 +73,18 @@ def test_calls_execute_ffmpeg_with_correct_args(mocker: MockerFixture) -> None:
         preset,
         "-codec:a",
         "copy",
-        # "-codec:s",
-        # "mov_text",
         "-bsf:a",
         "aac_adtstoasc",
         str(output_file),
     ]
     mock_execute_ffmpeg.assert_called_once_with(expected_args)
+    mock_get_media_info.assert_called_once_with(input_file)
 
 
 @pytest.mark.unit
-def test_calls_verify_streams_on_success(mocker: MockerFixture) -> None:
+def test_calls_verify_streams_on_success(
+    mocker: MockerFixture, mock_get_media_info: MagicMock
+) -> None:
     """Test that verify_streams is called on successful conversion."""
     # Arrange
     input_file = Path("input.ts")
@@ -83,10 +103,13 @@ def test_calls_verify_streams_on_success(mocker: MockerFixture) -> None:
     mock_verify_streams.assert_called_once_with(
         input_file=input_file, output_file=output_file, stream_type="audio"
     )
+    mock_get_media_info.assert_called_once_with(input_file)
 
 
 @pytest.mark.unit
-def test_ts2mp4_raises_runtime_error_on_ffmpeg_failure(mocker: MockerFixture) -> None:
+def test_ts2mp4_raises_runtime_error_on_ffmpeg_failure(
+    mocker: MockerFixture, mock_get_media_info: MagicMock
+) -> None:
     """Test that a RuntimeError is raised on ffmpeg failure."""
     # Arrange
     input_file = Path("input.ts")
@@ -103,11 +126,12 @@ def test_ts2mp4_raises_runtime_error_on_ffmpeg_failure(mocker: MockerFixture) ->
     # Act & Assert
     with pytest.raises(RuntimeError, match="ffmpeg failed with return code 1"):
         ts2mp4(input_file, output_file, crf, preset)
+    mock_get_media_info.assert_called_once_with(input_file)
 
 
 @pytest.mark.unit
 def test_does_not_call_verify_streams_on_ffmpeg_failure(
-    mocker: MockerFixture,
+    mocker: MockerFixture, mock_get_media_info: MagicMock
 ) -> None:
     """Test that ts2mp4 does not call verify_streams on failure."""
     # Arrange
@@ -127,10 +151,13 @@ def test_does_not_call_verify_streams_on_ffmpeg_failure(
         ts2mp4(input_file, output_file, crf, preset)
 
     mock_verify_streams.assert_not_called()
+    mock_get_media_info.assert_called_once_with(input_file)
 
 
 @pytest.mark.unit
-def test_ts2mp4_re_encodes_on_stream_integrity_failure(mocker: MockerFixture) -> None:
+def test_ts2mp4_re_encodes_on_stream_integrity_failure(
+    mocker: MockerFixture, mock_get_media_info: MagicMock
+) -> None:
     """Test that re-encoding is triggered on stream integrity failure."""
     # Arrange
     input_file = Path("input.ts")
@@ -158,10 +185,13 @@ def test_ts2mp4_re_encodes_on_stream_integrity_failure(mocker: MockerFixture) ->
         encoded_file=output_file,
         output_file=output_file.with_suffix(output_file.suffix + ".temp"),
     )
+    mock_get_media_info.assert_called_once_with(input_file)
 
 
 @pytest.mark.unit
-def test_ts2mp4_re_encode_failure_raises_error(mocker: MockerFixture) -> None:
+def test_ts2mp4_re_encode_failure_raises_error(
+    mocker: MockerFixture, mock_get_media_info: MagicMock
+) -> None:
     """Test that a RuntimeError is raised on re-encode failure."""
     # Arrange
     input_file = Path("input.ts")
@@ -185,3 +215,4 @@ def test_ts2mp4_re_encode_failure_raises_error(mocker: MockerFixture) -> None:
     # Act & Assert
     with pytest.raises(RuntimeError, match="Re-encode failed"):
         ts2mp4(input_file, output_file, crf, preset)
+    mock_get_media_info.assert_called_once_with(input_file)


### PR DESCRIPTION
Implement intelligent audio stream selection based on `ffprobe` to filter out invalid streams (those with 0 channels). This prevents conversion failures when an invalid audio stream is present in the input TS file.
Refine the construction of `ffmpeg_args` in `ts2mp4.py` by using list concatenation for audio stream mapping, improving readability and conciseness.
Update unit tests to reflect the new audio stream selection logic and ensure `get_media_info` is called.
