### PR TITLE
docs: Add guideline for referencing AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,6 +4,10 @@ This file provides guidelines and context for AI agents (like me) working on the
 
 For general project information, including project overview, technology stack, project structure, and development workflow, please refer to `README.md`.
 
+### Referencing Guidelines
+
+*   When referencing or applying guidelines from this `AGENTS.md` file, the agent will explicitly state that it is doing so in the conversation.
+
 ## 1. Coding Guidelines
 
 ### 1.1. Code Style


### PR DESCRIPTION
Adds a new guideline to AGENTS.md stating that the agent should explicitly mention when it is referencing or applying guidelines from AGENTS.md in the conversation. This improves transparency and helps the user understand the agent's decision-making process.
