### PR TITLE
feat: Automate releases on push to master

### DIFF
--- a/.github/workflows/ci-release.yml
+++ b/.github/workflows/ci-release.yml
@@ -35,64 +35,63 @@ jobs:
       - name: Run all checks
         run: make check
 
-  validate_release_tag:
+  validate_version_format:
     runs-on: ubuntu-latest
-    outputs:
-      is_valid_tag: ${{ steps.check_tag.outputs.is_valid_tag }}
-    if: startsWith(github.ref, 'refs/tags/') # Only run if it's a tag push
-    steps:
-      - name: Check tag format
-        id: check_tag
-        run: |
-          TAG_NAME=${{ github.ref }}
-          TAG_VERSION=$(echo $TAG_NAME | sed 's/^refs\/tags\///') # Remove refs/tags/
-
-          if [[ "$TAG_VERSION" =~ ^[0-9]{4}\.[0-9]{2}\.[0-9]{2}\.[0-9]+$ ]]; then
-            echo "Tag format is valid: $TAG_VERSION"
-            echo "is_valid_tag=true" >> $GITHUB_OUTPUT
-          else
-            echo "Tag format is invalid: $TAG_VERSION. Expected YYYY.MM.DD.X format."
-            echo "is_valid_tag=false" >> $GITHUB_OUTPUT
-          fi
-
-  release:
-    needs: [build, validate_release_tag]
-    runs-on: ubuntu-latest
-    if: needs.validate_release_tag.outputs.is_valid_tag == 'true'
     steps:
       - name: Checkout code
         uses: actions/checkout@v4.2.2
 
-      - name: Validate pyproject.toml version
-        id: validate_version
+      - name: Install poetry
+        run: pipx install poetry
+
+      - name: Check version format
         run: |
-          TAG_NAME=${{ github.ref }}
-          TAG_VERSION=$(echo $TAG_NAME | sed 's/^refs\/tags\///') # Remove refs/tags/
-
-          # Extract version from pyproject.toml using grep and sed
-          PYPROJECT_VERSION=$(grep '^version = ' pyproject.toml | sed -E 's/version = "(.*)"/\1/')
-
-          echo "Tag version: $TAG_VERSION"
-          echo "pyproject.toml version: $PYPROJECT_VERSION"
-
-          if [ "$TAG_VERSION" != "$PYPROJECT_VERSION" ]; then
-            echo "Error: Tag version ($TAG_VERSION) does not match pyproject.toml version ($PYPROJECT_VERSION)."
+          PYPROJECT_VERSION=$(poetry version --short)
+          if [[ "$PYPROJECT_VERSION" =~ ^[0-9]{4}\.[0-9]{2}\.[0-9]{2}\.[0-9]+$ ]]; then
+            echo "Version format is valid: $PYPROJECT_VERSION"
+          else
+            echo "Version format is invalid: $PYPROJECT_VERSION. Expected YYYY.MM.DD.X format."
             exit 1
           fi
-          echo "Tag and pyproject.toml versions match."
-          echo "release_version=$TAG_VERSION" >> $GITHUB_OUTPUT
 
-      - name: Create GitHub Release
+  release:
+    needs: [build, validate_version_format]
+    runs-on: ubuntu-latest
+    if: github.ref == 'refs/heads/master' && github.event_name == 'push'
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4.2.2
+
+      - name: Install poetry
+        run: pipx install poetry
+
+      - name: Get version
+        id: get_version
+        run: |
+          PYPROJECT_VERSION=$(poetry version --short)
+          echo "pyproject.toml version: $PYPROJECT_VERSION"
+          echo "release_version=$PYPROJECT_VERSION" >> $GITHUB_OUTPUT
+
+      - name: Check if release already exists
+        id: check_release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          TAG_NAME=${{ github.ref }}
-          RELEASE_NAME="Release ${{ steps.validate_version.outputs.release_version }}"
+          if gh release view ${{ steps.get_version.outputs.release_version }} >/dev/null 2>&1; then
+            echo "Release ${{ steps.get_version.outputs.release_version }} already exists."
+            echo "exists=true" >> $GITHUB_OUTPUT
+          else
+            echo "Release ${{ steps.get_version.outputs.release_version }} does not exist. Creating it."
+            echo "exists=false" >> $GITHUB_OUTPUT
+          fi
 
-          gh release create "$TAG_NAME" \
-            --generate-notes \
-            --draft=false \
-            --prerelease=false
+      - name: Create GitHub Release
+        if: steps.check_release.outputs.exists == 'false'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh release create "${{ steps.get_version.outputs.release_version }}" \
+            --generate-notes
 
   propose-version-update:
     runs-on: ubuntu-latest
@@ -167,7 +166,7 @@ jobs:
             echo "Creating a new pull request for branch '$BRANCH_NAME'."
             gh pr create \
               --title "build: Propose version update to ${{ steps.update_version.outputs.new_version }}" \
-              --body "This PR proposes an update to the project version." \
+              --body "This PR proposes an update to the project version. Merging this PR will trigger a new release." \
               --head "$BRANCH_NAME" \
               --base "master"
           fi

--- a/Makefile
+++ b/Makefile
@@ -48,22 +48,3 @@ $(TEST_ASSETS_DIR)/test_video.ts: Makefile
 		$@
 	@echo "Dummy video '$@' generated successfully."
 
-.PHONY: release
-release:
-	@if [ "$(shell git rev-parse --abbrev-ref HEAD)" != "master" ]; then \
-		echo "Error: You can only run 'make release' on the master branch."; \
-		exit 1; \
-	fi
-	@echo "Fetching latest from origin/master..."
-	@git fetch origin master || { echo "Error: Failed to fetch from origin/master. Please check your network connection or git configuration."; exit 1; }
-	@if [ "$(shell git rev-parse HEAD)" != "$(shell git rev-parse origin/master)" ]; then \
-		echo "Error: Your local master branch is not up-to-date with origin/master. Please pull the latest changes."; \
-		exit 1; \
-	fi
-	@echo "Getting version from pyproject.toml..."
-	$(eval VERSION := $(shell poetry version --short))
-	@echo "Version: $(VERSION)"
-	@echo "Creating git tag $(VERSION)..."
-	git tag $(VERSION)
-	@echo "Pushing git tag $(VERSION) to origin..."
-	git push origin $(VERSION)


### PR DESCRIPTION
This change modifies the release workflow to automatically create a GitHub release when a commit is pushed to the master branch.

The new workflow is as follows:
- On push to master, a 'release' job is triggered.
- The `release` job depends on the `build` and `validate_version_format` jobs.
- The job checks if a GitHub release for the version specified in `pyproject.toml` already exists.
- If the release does not exist, it creates a new one, including a new git tag and auto-generated release notes.
- The `propose-version-update` job, which automatically bumps the version and creates a PR, is updated to notify that merging the PR will trigger a release.
- A new `validate_version_format` job is added to run on all pushes and pull requests to ensure the version in `pyproject.toml` is correctly formatted. This job now uses `poetry version --short` to get the version.

The manual `make release` command has been removed as it is no longer necessary.