### PR TITLE
ci: cancel concurrent workflows

### DIFF
--- a/.github/workflows/ci-release.yml
+++ b/.github/workflows/ci-release.yml
@@ -7,6 +7,10 @@ on:
   pull_request:
     branches: ["**"]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Adds a concurrency group to the CI workflow.

This ensures that for any given branch, only one instance of the workflow is running at a time. If a new workflow is triggered on the same branch, any previously running workflow will be canceled.