### PR TITLE
fix(ci): Use force push for auto-version-update branch

### DIFF
--- a/.github/workflows/ci-release.yml
+++ b/.github/workflows/ci-release.yml
@@ -162,7 +162,7 @@ jobs:
           git checkout -B "$BRANCH_NAME"
           git add pyproject.toml
           git commit -m "build: update version to ${{ steps.update_version.outputs.new_version }}"
-          git push --force-with-lease origin "$BRANCH_NAME"
+          git push --force origin "$BRANCH_NAME"
 
       - name: Create/Update Pull Request
         if: steps.update_version.outputs.version_updated == 'true'


### PR DESCRIPTION
The 'Prepare Version Update Branch' step in the `ci-release` workflow was failing with a "stale info" error. This occurred because `git push --force-with-lease` correctly prevents overwriting the remote `feature/auto-version-update` branch when its history has diverged from the local branch created by the workflow.

This commit replaces `--force-with-lease` with `--force`. This change ensures that the automated branch is always updated to reflect the latest state of the `master` branch, which is the intended behavior for this specific workflow. The concurrency controls within the GitHub Actions workflow make this operation safe from race conditions.