### PR TITLE
fix(quality): Suppress ffmpeg progress output

### DIFF
--- a/ts2mp4/quality_check.py
+++ b/ts2mp4/quality_check.py
@@ -69,6 +69,8 @@ def get_audio_quality_metrics(
         An AudioQualityMetrics namedtuple containing apsnr and asdr, or None if metrics could not be calculated.
     """
     command = [
+        "-hide_banner",
+        "-nostats",
         "-i",
         str(original_file),
         "-i",


### PR DESCRIPTION
Adds `-hide_banner` and `-nostats` flags to the ffmpeg command in
`get_audio_quality_metrics` to prevent progress output from cluttering
the logs.
