### PR TITLE
Refactor: Streamlined FFmpeg command streaming and error handling

### DIFF
--- a/tests/test_hashing.py
+++ b/tests/test_hashing.py
@@ -10,16 +10,16 @@ from ts2mp4.hashing import _get_stream_md5_cached, get_stream_md5
 from ts2mp4.media_info import Stream
 
 
-def mock_ffmpeg_stream_success() -> Generator[bytes, None, tuple[int, str]]:
+def mock_ffmpeg_stream_success() -> Generator[bytes, None, int]:
     """Mock of successful ffmpeg stream."""
     yield b"stream_data"
-    return 0, ""
+    return 0
 
 
-def mock_ffmpeg_stream_failure() -> Generator[bytes, None, tuple[int, str]]:
+def mock_ffmpeg_stream_failure() -> Generator[bytes, None, int]:
     """Mock of failed ffmpeg stream."""
     yield from ()
-    return 1, "ffmpeg error"
+    return 1
 
 
 @pytest.fixture(autouse=True)

--- a/ts2mp4/ffmpeg.py
+++ b/ts2mp4/ffmpeg.py
@@ -49,10 +49,13 @@ def _run_command(
     return FFmpegResult(stdout=stdout, stderr=stderr, returncode=process.returncode)
 
 
-def _stream_command(
+def _stream_stdout(
     executable: Literal["ffmpeg", "ffprobe"], args: list[str]
-) -> Generator[bytes, None, tuple[int, str]]:
+) -> Generator[bytes, None, int]:
     """Execute a process and yield its stdout in chunks.
+
+    This function runs a command as a subprocess, yielding its standard output
+    in 1KB chunks. Standard error is captured and logged internally.
 
     Args:
     ----
@@ -65,7 +68,7 @@ def _stream_command(
 
     Returns
     -------
-        tuple[int, str]: A tuple containing the return code and stderr of the process.
+        int: The return code of the process after it completes.
 
     Raises
     ------
@@ -92,7 +95,7 @@ def _stream_command(
         logger.info(stderr)
 
     process.wait()
-    return process.returncode, stderr
+    return process.returncode
 
 
 def execute_ffmpeg(args: list[str]) -> FFmpegResult:
@@ -112,7 +115,7 @@ def execute_ffmpeg(args: list[str]) -> FFmpegResult:
 
 def execute_ffmpeg_streamed(
     args: list[str],
-) -> Generator[bytes, None, tuple[int, str]]:
+) -> Generator[bytes, None, int]:
     """Execute ffmpeg and returns a generator for stdout.
 
     Args:
@@ -122,9 +125,9 @@ def execute_ffmpeg_streamed(
     Returns
     -------
         A generator that yields stdout in chunks.
-        The generator's return value is a tuple of (returncode, stderr).
+        The generator's return value is the returncode.
     """
-    return _stream_command("ffmpeg", args)
+    return _stream_stdout("ffmpeg", args)
 
 
 def execute_ffprobe(args: list[str]) -> FFmpegResult:

--- a/ts2mp4/hashing.py
+++ b/ts2mp4/hashing.py
@@ -43,7 +43,7 @@ def _get_stream_md5_cached(
             chunk = next(process_generator)
             md5_hash.update(chunk)
     except StopIteration as e:
-        returncode, _ = e.value
+        returncode = e.value
 
     if returncode != 0:
         raise RuntimeError(


### PR DESCRIPTION
- Renamed `_stream_command` to `_stream_stdout` for clarity, reflecting its role in streaming standard output.
- Updated `execute_ffmpeg_streamed` to align with the new `_stream_stdout` interface.
- Adjusted `_get_stream_md5_cached` and related test mocks to accommodate the simplified return type of streamed commands (no longer returning stderr).
- Refactored `test_handles_non_utf8_output_output_stream_command` to `test_handles_non_utf8_output_stream_stdout`, now verifying stderr logging via `logzero.logger.info` mock.
