### PR TITLE
Fix: Resolve Pylance type hint for process.returncode

### DIFF
--- a/ts2mp4/ffmpeg.py
+++ b/ts2mp4/ffmpeg.py
@@ -95,7 +95,7 @@ def _stream_stdout(
         logger.info(stderr)
 
     process.wait()
-    return process.returncode
+    return int(process.returncode)
 
 
 def execute_ffmpeg(args: list[str]) -> FFmpegResult:

--- a/ts2mp4/ffmpeg.py
+++ b/ts2mp4/ffmpeg.py
@@ -94,8 +94,7 @@ def _stream_stdout(
     if stderr:
         logger.info(stderr)
 
-    process.wait()
-    return int(process.returncode)
+    return process.wait()
 
 
 def execute_ffmpeg(args: list[str]) -> FFmpegResult:


### PR DESCRIPTION
Explicitly cast `process.returncode` to `int` in `_stream_stdout` to satisfy static type checkers like Pylance. While `process.returncode` is guaranteed to be an integer after `process.wait()`, the explicit cast clarifies the type for analysis tools.
