### PR TITLE
refactor: Use VideoFile objects in audio re-encoding and stream integrity checks

### DIFF
--- a/tests/test_stream_integrity.py
+++ b/tests/test_stream_integrity.py
@@ -1,113 +1,136 @@
 """Unit tests for the stream_integrity module."""
 
 from pathlib import Path
+from typing import cast
+from unittest.mock import MagicMock
 
 import pytest
 from pytest_mock import MockerFixture
 
 from ts2mp4.media_info import MediaInfo, Stream
 from ts2mp4.stream_integrity import compare_stream_hashes, verify_streams
+from ts2mp4.video_file import VideoFile
+
+
+@pytest.fixture
+def mock_input_video_file(mocker: MockerFixture) -> MagicMock:
+    """Return a mocked input VideoFile instance."""
+    mock_input = cast(MagicMock, mocker.MagicMock(spec=VideoFile))
+    mock_input.path = Path("dummy_input.ts")
+    # Set default media_info for input, can be overridden in tests if needed
+    mock_input.media_info = MediaInfo(
+        streams=(
+            Stream(codec_type="video", index=0),
+            Stream(codec_type="audio", index=1),
+        )
+    )
+    return mock_input
+
+
+@pytest.fixture
+def mock_output_video_file(mocker: MockerFixture) -> MagicMock:
+    """Return a mocked output VideoFile instance."""
+    mock_output = cast(MagicMock, mocker.MagicMock(spec=VideoFile))
+    mock_output.path = Path("dummy_output.mp4.part")
+    # Set default media_info for output, can be overridden in tests if needed
+    mock_output.media_info = MediaInfo(
+        streams=(
+            Stream(codec_type="video", index=0),
+            Stream(codec_type="audio", index=1),
+        )
+    )
+    return mock_output
 
 
 @pytest.mark.unit
-def test_compare_stream_hashes_matching_hashes(mocker: MockerFixture) -> None:
+def test_compare_stream_hashes_matching_hashes(
+    mocker: MockerFixture,
+    mock_input_video_file: MagicMock,
+    mock_output_video_file: MagicMock,
+) -> None:
     """Tests that compare_stream_hashes returns True when MD5 hashes match."""
     mocker.patch("ts2mp4.stream_integrity.get_stream_md5", return_value="same_hash")
-    input_file = Path("dummy_input.ts")
-    output_file = Path("dummy_output.mp4.part")
+
     stream = Stream(codec_type="audio", index=1)
 
-    assert compare_stream_hashes(input_file, output_file, stream, stream)
+    assert compare_stream_hashes(
+        input_video=mock_input_video_file,
+        output_video=mock_output_video_file,
+        input_stream=stream,
+        output_stream=stream,
+    )
 
 
 @pytest.mark.unit
-def test_compare_stream_hashes_mismatching_hashes(mocker: MockerFixture) -> None:
+def test_compare_stream_hashes_mismatching_hashes(
+    mocker: MockerFixture,
+    mock_input_video_file: MagicMock,
+    mock_output_video_file: MagicMock,
+) -> None:
     """Tests that compare_stream_hashes returns False when MD5 hashes mismatch."""
     mocker.patch(
         "ts2mp4.stream_integrity.get_stream_md5", side_effect=["hash1", "hash2"]
     )
-    input_file = Path("dummy_input.ts")
-    output_file = Path("dummy_output.mp4.part")
     stream = Stream(codec_type="audio", index=1)
 
-    assert not compare_stream_hashes(input_file, output_file, stream, stream)
+    assert not compare_stream_hashes(
+        input_video=mock_input_video_file,
+        output_video=mock_output_video_file,
+        input_stream=stream,
+        output_stream=stream,
+    )
 
 
 @pytest.mark.unit
-def test_compare_stream_hashes_hash_generation_fails(mocker: MockerFixture) -> None:
+def test_compare_stream_hashes_hash_generation_fails(
+    mocker: MockerFixture,
+    mock_input_video_file: MagicMock,
+    mock_output_video_file: MagicMock,
+) -> None:
     """Tests that compare_stream_hashes returns False when hash generation fails."""
     mocker.patch(
         "ts2mp4.stream_integrity.get_stream_md5",
         side_effect=RuntimeError("Mock error"),
     )
-    input_file = Path("dummy_input.ts")
-    output_file = Path("dummy_output.mp4.part")
     stream = Stream(codec_type="audio", index=1)
 
-    assert not compare_stream_hashes(input_file, output_file, stream, stream)
+    assert not compare_stream_hashes(
+        input_video=mock_input_video_file,
+        output_video=mock_output_video_file,
+        input_stream=stream,
+        output_stream=stream,
+    )
 
 
 @pytest.mark.unit
-def test_verify_streams_matches(mocker: MockerFixture) -> None:
+def test_verify_streams_matches(
+    mocker: MockerFixture,
+    mock_input_video_file: MagicMock,
+    mock_output_video_file: MagicMock,
+) -> None:
     """Tests that no exception is raised when all stream hashes match."""
-    input_file = Path("dummy_input.ts")
-    output_file = Path("dummy_output.mp4.part")
-
-    mocker.patch(
-        "ts2mp4.stream_integrity.get_media_info",
-        side_effect=[
-            MediaInfo(
-                streams=(
-                    Stream(codec_type="video", index=0),
-                    Stream(codec_type="audio", index=1),
-                )
-            ),
-            MediaInfo(
-                streams=(
-                    Stream(codec_type="video", index=0),
-                    Stream(codec_type="audio", index=1),
-                )
-            ),
-        ],
-    )
     mock_compare_stream_hashes = mocker.patch(
         "ts2mp4.stream_integrity.compare_stream_hashes", return_value=True
     )
 
-    verify_streams(input_file, output_file, "audio")
+    verify_streams(mock_input_video_file, mock_output_video_file, "audio")
 
     mock_compare_stream_hashes.assert_called_once()
 
 
 @pytest.mark.unit
-def test_verify_streams_mismatch(mocker: MockerFixture) -> None:
+def test_verify_streams_mismatch(
+    mocker: MockerFixture,
+    mock_input_video_file: MagicMock,
+    mock_output_video_file: MagicMock,
+) -> None:
     """Tests that a RuntimeError is raised when stream hashes mismatch."""
-    input_file = Path("dummy_input.ts")
-    output_file = Path("dummy_output.mp4.part")
-
-    mocker.patch(
-        "ts2mp4.stream_integrity.get_media_info",
-        side_effect=[
-            MediaInfo(
-                streams=(
-                    Stream(codec_type="video", index=0),
-                    Stream(codec_type="audio", index=1),
-                )
-            ),
-            MediaInfo(
-                streams=(
-                    Stream(codec_type="video", index=0),
-                    Stream(codec_type="audio", index=1),
-                )
-            ),
-        ],
-    )
     mock_compare_stream_hashes = mocker.patch(
         "ts2mp4.stream_integrity.compare_stream_hashes", return_value=False
     )
 
     with pytest.raises(RuntimeError) as excinfo:
-        verify_streams(input_file, output_file, "audio")
+        verify_streams(mock_input_video_file, mock_output_video_file, "audio")
 
     assert "Audio stream integrity check failed for stream at index 1" in str(
         excinfo.value
@@ -118,115 +141,119 @@ def test_verify_streams_mismatch(mocker: MockerFixture) -> None:
 @pytest.mark.unit
 def test_verify_streams_stream_count_mismatch(
     mocker: MockerFixture,
+    mock_input_video_file: MagicMock,
+    mock_output_video_file: MagicMock,
 ) -> None:
     """Tests that a RuntimeError is raised for mismatched audio stream counts."""
-    input_file = Path("dummy_input.ts")
-    output_file = Path("dummy_output.mp4.part")
-
-    mocker.patch(
-        "ts2mp4.stream_integrity.get_media_info",
-        side_effect=[
-            MediaInfo(
-                streams=(
-                    Stream(codec_type="video", index=0),
-                    Stream(codec_type="audio", index=1),
-                )
-            ),
-            MediaInfo(streams=(Stream(codec_type="video", index=0),)),
-        ],
+    # Override media_info for this specific test case
+    mock_input_video_file.media_info = MediaInfo(
+        streams=(
+            Stream(codec_type="video", index=0),
+            Stream(codec_type="audio", index=1),
+        )
+    )
+    mock_output_video_file.media_info = MediaInfo(
+        streams=(Stream(codec_type="video", index=0),)
     )
 
     with pytest.raises(RuntimeError) as excinfo:
-        verify_streams(input_file, output_file, "audio")
+        verify_streams(mock_input_video_file, mock_output_video_file, "audio")
     assert "Mismatch in the number of audio streams" in str(excinfo.value)
 
 
 @pytest.mark.unit
-def test_verify_streams_no_audio_streams(mocker: MockerFixture) -> None:
+def test_verify_streams_no_audio_streams(
+    mocker: MockerFixture,
+    mock_input_video_file: MagicMock,
+    mock_output_video_file: MagicMock,
+) -> None:
     """Tests correct handling when there are no audio streams."""
-    input_file = Path("dummy_input_no_audio.ts")
-    output_file = Path("dummy_output_no_audio.mp4.part")
-
-    mocker.patch(
-        "ts2mp4.stream_integrity.get_media_info",
-        return_value=MediaInfo(
-            streams=(
-                Stream(codec_type="video", index=0),
-                Stream(codec_type="subtitle", index=1),
-            )
-        ),
+    # Override media_info for this specific test case
+    mock_input_video_file.media_info = MediaInfo(
+        streams=(
+            Stream(codec_type="video", index=0),
+            Stream(codec_type="subtitle", index=1),
+        )
     )
+    mock_output_video_file.media_info = MediaInfo(
+        streams=(
+            Stream(codec_type="video", index=0),
+            Stream(codec_type="subtitle", index=1),
+        )
+    )
+
     mock_compare_stream_hashes = mocker.patch(
         "ts2mp4.stream_integrity.compare_stream_hashes"
     )
 
-    verify_streams(input_file, output_file, "audio")
+    verify_streams(mock_input_video_file, mock_output_video_file, "audio")
 
     mock_compare_stream_hashes.assert_not_called()
 
 
 @pytest.mark.unit
-def test_verify_streams_specific_indices(mocker: MockerFixture) -> None:
+def test_verify_streams_specific_indices(
+    mocker: MockerFixture,
+    mock_input_video_file: MagicMock,
+    mock_output_video_file: MagicMock,
+) -> None:
     """Tests that verify_streams correctly checks specific stream indices."""
-    input_file = Path("dummy_input.ts")
-    output_file = Path("dummy_output.mp4.part")
-
-    mocker.patch(
-        "ts2mp4.stream_integrity.get_media_info",
-        side_effect=[
-            MediaInfo(
-                streams=(
-                    Stream(codec_type="audio", index=0),
-                    Stream(codec_type="audio", index=1),
-                )
-            ),
-            MediaInfo(
-                streams=(
-                    Stream(codec_type="audio", index=0),
-                    Stream(codec_type="audio", index=1),
-                )
-            ),
-        ],
+    # Override media_info for this specific test case
+    mock_input_video_file.media_info = MediaInfo(
+        streams=(
+            Stream(codec_type="audio", index=0),
+            Stream(codec_type="audio", index=1),
+        )
     )
+    mock_output_video_file.media_info = MediaInfo(
+        streams=(
+            Stream(codec_type="audio", index=0),
+            Stream(codec_type="audio", index=1),
+        )
+    )
+
     mock_compare_stream_hashes = mocker.patch(
         "ts2mp4.stream_integrity.compare_stream_hashes", return_value=True
     )
 
-    verify_streams(input_file, output_file, "audio", type_specific_stream_indices=[1])
+    verify_streams(
+        mock_input_video_file,
+        mock_output_video_file,
+        "audio",
+        type_specific_stream_indices=[1],
+    )
 
     # Ensures that only the stream at index 1 is checked
     assert mock_compare_stream_hashes.call_count == 1
-    checked_stream = mock_compare_stream_hashes.call_args[0][2]
+    checked_stream = mock_compare_stream_hashes.call_args.kwargs["input_stream"]
     assert checked_stream.index == 1
 
 
 @pytest.mark.unit
-def test_verify_streams_video_mismatch(mocker: MockerFixture) -> None:
+def test_verify_streams_video_mismatch(
+    mocker: MockerFixture,
+    mock_input_video_file: MagicMock,
+    mock_output_video_file: MagicMock,
+) -> None:
     """Tests that a RuntimeError is raised for video stream mismatch."""
-    input_file = Path("dummy_input.ts")
-    output_file = Path("dummy_output.mp4.part")
-
-    mocker.patch(
-        "ts2mp4.stream_integrity.get_media_info",
-        side_effect=[
-            MediaInfo(
-                streams=(
-                    Stream(codec_type="video", index=0),
-                    Stream(codec_type="audio", index=1),
-                )
-            ),
-            MediaInfo(
-                streams=(
-                    Stream(codec_type="video", index=0),
-                    Stream(codec_type="audio", index=1),
-                )
-            ),
-        ],
+    # Override media_info for this specific test case
+    mock_input_video_file.media_info = MediaInfo(
+        streams=(
+            Stream(codec_type="video", index=0),
+            Stream(codec_type="audio", index=1),
+        )
     )
+    mock_output_video_file.media_info = MediaInfo(
+        streams=(
+            Stream(codec_type="video", index=0),
+            Stream(codec_type="audio", index=1),
+        )
+    )
+
     mocker.patch("ts2mp4.stream_integrity.compare_stream_hashes", return_value=False)
 
     with pytest.raises(RuntimeError) as excinfo:
-        verify_streams(input_file, output_file, "video")
+        verify_streams(mock_input_video_file, mock_output_video_file, "video")
 
     assert "Video stream integrity check failed for stream at index 0" in str(
         excinfo.value

--- a/tests/test_ts2mp4.py
+++ b/tests/test_ts2mp4.py
@@ -36,6 +36,14 @@ def test_calls_execute_ffmpeg_with_correct_args(
     crf = 23
     preset = "medium"
 
+    # Mock VideoFile constructor to prevent file existence check
+    mock_output_video_file_instance = mocker.MagicMock(spec=VideoFile)
+    mock_output_video_file_instance.path = output_file
+    mock_output_video_file_instance.media_info = MagicMock()  # Add a mock media_info
+    mocker.patch(
+        "ts2mp4.ts2mp4.VideoFile", return_value=mock_output_video_file_instance
+    )
+
     mock_execute_ffmpeg = mocker.patch("ts2mp4.ts2mp4.execute_ffmpeg")
     mock_execute_ffmpeg.return_value = FFmpegResult(stdout=b"", stderr="", returncode=0)
     mocker.patch("ts2mp4.ts2mp4.verify_streams")
@@ -89,6 +97,13 @@ def test_calls_verify_streams_on_success(
     crf = 23
     preset = "medium"
 
+    mock_output_video_file_instance = mocker.MagicMock(spec=VideoFile)
+    mock_output_video_file_instance.path = output_file
+    mock_output_video_file_instance.media_info = MagicMock()
+    mocker.patch(
+        "ts2mp4.ts2mp4.VideoFile", return_value=mock_output_video_file_instance
+    )
+
     mock_execute_ffmpeg = mocker.patch("ts2mp4.ts2mp4.execute_ffmpeg")
     mock_execute_ffmpeg.return_value = FFmpegResult(stdout=b"", stderr="", returncode=0)
     mock_verify_streams = mocker.patch("ts2mp4.ts2mp4.verify_streams")
@@ -98,7 +113,9 @@ def test_calls_verify_streams_on_success(
 
     # Assert
     mock_verify_streams.assert_called_once_with(
-        input_file=mock_video_file.path, output_file=output_file, stream_type="audio"
+        input_file=mock_video_file,
+        output_file=mock_output_video_file_instance,
+        stream_type="audio",
     )
 
 
@@ -111,6 +128,13 @@ def test_ts2mp4_raises_runtime_error_on_ffmpeg_failure(
     output_file = Path("output.mp4")
     crf = 23
     preset = "medium"
+
+    mock_output_video_file_instance = mocker.MagicMock(spec=VideoFile)
+    mock_output_video_file_instance.path = output_file
+    mock_output_video_file_instance.media_info = MagicMock()
+    mocker.patch(
+        "ts2mp4.ts2mp4.VideoFile", return_value=mock_output_video_file_instance
+    )
 
     mocker.patch("ts2mp4.ts2mp4.verify_streams")
     mock_execute_ffmpeg = mocker.patch("ts2mp4.ts2mp4.execute_ffmpeg")
@@ -132,6 +156,13 @@ def test_does_not_call_verify_streams_on_ffmpeg_failure(
     output_file = Path("output.mp4")
     crf = 23
     preset = "medium"
+
+    mock_output_video_file_instance = mocker.MagicMock(spec=VideoFile)
+    mock_output_video_file_instance.path = output_file
+    mock_output_video_file_instance.media_info = MagicMock()
+    mocker.patch(
+        "ts2mp4.ts2mp4.VideoFile", return_value=mock_output_video_file_instance
+    )
 
     mock_execute_ffmpeg = mocker.patch("ts2mp4.ts2mp4.execute_ffmpeg")
     mock_verify_streams = mocker.patch("ts2mp4.ts2mp4.verify_streams")
@@ -156,6 +187,13 @@ def test_ts2mp4_re_encodes_on_stream_integrity_failure(
     crf = 23
     preset = "medium"
 
+    mock_output_video_file_instance = mocker.MagicMock(spec=VideoFile)
+    mock_output_video_file_instance.path = output_file
+    mock_output_video_file_instance.media_info = MagicMock()
+    mocker.patch(
+        "ts2mp4.ts2mp4.VideoFile", return_value=mock_output_video_file_instance
+    )
+
     mocker.patch(
         "ts2mp4.ts2mp4.execute_ffmpeg",
         return_value=FFmpegResult(stdout=b"", stderr="", returncode=0),
@@ -172,8 +210,8 @@ def test_ts2mp4_re_encodes_on_stream_integrity_failure(
 
     # Assert
     mock_re_encode.assert_called_once_with(
-        original_file=mock_video_file.path,
-        encoded_file=output_file,
+        original_file=mock_video_file,
+        encoded_file=mock_output_video_file_instance,
         output_file=output_file.with_suffix(output_file.suffix + ".temp"),
     )
 
@@ -187,6 +225,13 @@ def test_ts2mp4_re_encode_failure_raises_error(
     output_file = Path("output.mp4")
     crf = 23
     preset = "medium"
+
+    mock_output_video_file_instance = mocker.MagicMock(spec=VideoFile)
+    mock_output_video_file_instance.path = output_file
+    mock_output_video_file_instance.media_info = MagicMock()
+    mocker.patch(
+        "ts2mp4.ts2mp4.VideoFile", return_value=mock_output_video_file_instance
+    )
 
     mocker.patch(
         "ts2mp4.ts2mp4.execute_ffmpeg",

--- a/ts2mp4/ts2mp4.py
+++ b/ts2mp4/ts2mp4.py
@@ -73,17 +73,20 @@ def ts2mp4(input_file: VideoFile, output_file: Path, crf: int, preset: str) -> N
     if result.returncode != 0:
         raise RuntimeError(f"ffmpeg failed with return code {result.returncode}")
 
+    output_file_video_file = VideoFile(path=output_file)
     try:
         verify_streams(
-            input_file=input_file.path, output_file=output_file, stream_type="audio"
+            input_file=input_file,
+            output_file=output_file_video_file,
+            stream_type="audio",
         )
     except RuntimeError as e:
         logger.warning(f"Audio integrity check failed: {e}")
         logger.info("Attempting to re-encode mismatched audio streams.")
         temp_output_file = output_file.with_suffix(output_file.suffix + ".temp")
         re_encode_mismatched_audio_streams(
-            original_file=input_file.path,
-            encoded_file=output_file,
+            original_file=input_file,
+            encoded_file=output_file_video_file,
             output_file=temp_output_file,
         )
         temp_output_file.replace(output_file)


### PR DESCRIPTION
Refactors `audio_reencoder.py`, `stream_integrity.py`, and `ts2mp4.py` to
utilize `VideoFile` objects instead of direct `Path` objects for input and
output files. This change improves encapsulation and consistency by
centralizing media information access within the `VideoFile` class.

- Updates `_build_args_for_audio_streams` to accept `VideoFile` instances.
- Modifies `re_encode_mismatched_audio_streams` to use `VideoFile` objects.
- Adjusts `compare_stream_hashes` and `verify_streams` to operate on `VideoFile` objects.
- Updates `ts2mp4` to pass `VideoFile` objects to integrity checks and re-encoding.
- Aligns corresponding unit tests in `tests/test_audio_reencoder.py`,
  `tests/test_stream_integrity.py`, and `tests/test_ts2mp4.py` to the new API.
