### PR TITLE
Refactor: Improve ts2mp4 function modularity and testability

### DIFF
--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -54,7 +54,7 @@ def test_cli_options_recognized(mocker: MockerFixture, tmp_path: Path) -> None:
     assert result.exit_code == 0
     mock_ts2mp4.assert_called_once_with(
         input_file=mocker.ANY,
-        output_file=mocker.ANY,
+        output_path=mocker.ANY,
         crf=20,
         preset="slow",
     )

--- a/ts2mp4/cli.py
+++ b/ts2mp4/cli.py
@@ -96,7 +96,9 @@ def main(
             return
 
         video_file = VideoFile(path=ts_resolved)
-        ts2mp4(input_file=video_file, output_file=mp4_part, crf=crf, preset=preset)
+        ts2mp4(
+            input_file=video_file, output_path=mp4_part, crf=crf, preset=preset.value
+        )
 
         logger.info("Conversion Status: Success")
 


### PR DESCRIPTION
Refactored the `ts2mp4` function in `ts2mp4/ts2mp4.py` to enhance modularity and testability.
- Extracted FFmpeg argument building logic into `_build_ffmpeg_conversion_args`.
- Encapsulated initial FFmpeg execution into `_perform_initial_conversion`.
- Renamed `output_file` parameter to `output_path` for clarity and consistency across the codebase.
- Updated `ts2mp4/cli.py` and test files (`tests/test_cli.py`, `tests/test_ts2mp4.py`) to reflect these changes.
- Added new unit tests for the extracted helper functions.
