### PR TITLE
feat: Add robust integrity checks for copied streams

### DIFF
--- a/ts2mp4/stream_integrity.py
+++ b/ts2mp4/stream_integrity.py
@@ -6,7 +6,7 @@ from logzero import logger
 
 from .hashing import get_stream_md5
 from .media_info import Stream
-from .video_file import VideoFile
+from .video_file import ConversionType, ConvertedVideoFile, VideoFile
 
 
 def compare_stream_hashes(
@@ -106,3 +106,36 @@ def verify_streams(
     logger.info(
         f"{stream_type.capitalize()} stream integrity verified successfully. All MD5 hashes match."
     )
+
+
+def verify_copied_streams(converted_file: ConvertedVideoFile) -> None:
+    """Verify the integrity of copied streams by comparing their MD5 hashes.
+
+    Args:
+    ----
+        converted_file: The ConvertedVideoFile object.
+
+    Raises
+    ------
+        RuntimeError: If any copied stream's MD5 hash does not match.
+    """
+    logger.info(f"Verifying copied stream integrity for {converted_file.path.name}")
+
+    for i, stream_source in enumerate(converted_file.stream_sources):
+        if stream_source.conversion_type != ConversionType.COPIED:
+            continue
+
+        output_stream = converted_file.media_info.streams[i]
+        if not compare_stream_hashes(
+            input_video=stream_source.source_video_file,
+            output_video=converted_file,
+            input_stream=stream_source.source_stream,
+            output_stream=output_stream,
+        ):
+            codec_type = stream_source.source_stream.codec_type or "Unknown"
+            raise RuntimeError(
+                f"{codec_type.capitalize()} stream integrity check "
+                f"failed for stream at index {stream_source.source_stream.index}"
+            )
+
+    logger.info("Copied stream integrity verified successfully. All MD5 hashes match.")

--- a/ts2mp4/ts2mp4.py
+++ b/ts2mp4/ts2mp4.py
@@ -7,7 +7,7 @@ from typing_extensions import Self
 
 from .audio_reencoder import re_encode_mismatched_audio_streams
 from .ffmpeg import execute_ffmpeg
-from .stream_integrity import verify_streams
+from .stream_integrity import verify_copied_streams
 from .video_file import (
     ConversionType,
     ConvertedVideoFile,
@@ -160,11 +160,7 @@ def ts2mp4(input_file: VideoFile, output_path: Path, crf: int, preset: str) -> N
     output_file = _perform_initial_conversion(input_file, output_path, crf, preset)
 
     try:
-        verify_streams(
-            input_file=input_file,
-            output_file=output_file,
-            stream_type="audio",
-        )
+        verify_copied_streams(converted_file=output_file)
     except RuntimeError as e:
         logger.warning(f"Audio integrity check failed: {e}")
         logger.info("Attempting to re-encode mismatched audio streams.")


### PR DESCRIPTION
This commit introduces a more robust stream integrity verification process by leveraging the structured `stream_sources` data in the `ConvertedVideoFile` object.

Key changes include:
- A new `verify_copied_streams` function has been added to `ts2mp4/stream_integrity.py`. This function specifically verifies streams that were copied (not re-encoded) during the conversion process by comparing their hashes.
- The main `ts2mp4` function in `ts2mp4/ts2mp4.py` has been updated to use this new `verify_copied_streams` function, replacing the previous, more generic verification.
- The original `verify_streams` function is preserved to maintain compatibility with the audio re-encoding process, which uses it independently.
- New unit tests for `verify_copied_streams` have been added in `tests/test_stream_integrity.py` to ensure its correctness.
- Existing tests in `tests/test_ts2mp4.py` have been updated to reflect the new function call.
