### PR TITLE
Refactor: Introduce InitiallyConvertedVideoFile for clarity

### DIFF
--- a/tests/test_initial_converter.py
+++ b/tests/test_initial_converter.py
@@ -14,12 +14,7 @@ from ts2mp4.initial_converter import (
     perform_initial_conversion,
 )
 from ts2mp4.media_info import MediaInfo, Stream
-from ts2mp4.video_file import (
-    ConversionType,
-    StreamSource,
-    StreamSources,
-    VideoFile,
-)
+from ts2mp4.video_file import ConversionType, StreamSource, StreamSources, VideoFile
 
 
 @pytest.fixture
@@ -273,7 +268,7 @@ def test_perform_initial_conversion_success(
     )
 
     mocker.patch(
-        "ts2mp4.initial_converter.ConvertedVideoFile",
+        "ts2mp4.initial_converter.InitiallyConvertedVideoFile",
         return_value=mocker.MagicMock(spec=VideoFile, path=output_file),
     )
     perform_initial_conversion(mock_video_file, output_file, crf, preset)

--- a/ts2mp4/initial_converter.py
+++ b/ts2mp4/initial_converter.py
@@ -61,6 +61,12 @@ class StreamSourcesForInitialConversion(StreamSources):
         return self[0].source_video_file
 
 
+class InitiallyConvertedVideoFile(ConvertedVideoFile):
+    """Represents a ConvertedVideoFile that has undergone the initial conversion."""
+
+    stream_sources: StreamSourcesForInitialConversion
+
+
 def _build_stream_sources(input_file: VideoFile) -> StreamSourcesForInitialConversion:
     """Build the stream sources for the initial conversion."""
     stream_sources = StreamSources(
@@ -126,7 +132,7 @@ def _build_ffmpeg_args_from_stream_sources(
 
 def perform_initial_conversion(
     input_file: VideoFile, output_path: Path, crf: int, preset: str
-) -> ConvertedVideoFile:
+) -> InitiallyConvertedVideoFile:
     """Perform the initial FFmpeg conversion from TS to MP4."""
     stream_sources = _build_stream_sources(input_file)
     ffmpeg_args = _build_ffmpeg_args_from_stream_sources(
@@ -135,4 +141,4 @@ def perform_initial_conversion(
     result = execute_ffmpeg(ffmpeg_args)
     if result.returncode != 0:
         raise RuntimeError(f"ffmpeg failed with return code {result.returncode}")
-    return ConvertedVideoFile(path=output_path, stream_sources=stream_sources)
+    return InitiallyConvertedVideoFile(path=output_path, stream_sources=stream_sources)

--- a/ts2mp4/ts2mp4.py
+++ b/ts2mp4/ts2mp4.py
@@ -26,17 +26,19 @@ def ts2mp4(input_file: VideoFile, output_path: Path, crf: int, preset: str) -> N
             speed and efficiency (e.g., 'medium', 'fast', 'slow').
 
     """
-    output_file = perform_initial_conversion(input_file, output_path, crf, preset)
+    initially_converted_video_file = perform_initial_conversion(
+        input_file, output_path, crf, preset
+    )
 
     try:
-        verify_copied_streams(converted_file=output_file)
+        verify_copied_streams(converted_file=initially_converted_video_file)
     except RuntimeError as e:
         logger.warning(f"Audio integrity check failed: {e}")
         logger.info("Attempting to re-encode mismatched audio streams.")
         temp_output_file = output_path.with_suffix(output_path.suffix + ".temp")
         re_encode_mismatched_audio_streams(
             original_file=input_file,
-            encoded_file=output_file,
+            encoded_file=initially_converted_video_file,
             output_file=temp_output_file,
         )
         temp_output_file.replace(output_path)


### PR DESCRIPTION
Introduces a new class `InitiallyConvertedVideoFile` to explicitly represent video files that have undergone the initial conversion process. This improves type safety and clarifies the state of the video file after this specific conversion step.

- Renamed `output_file` to `initially_converted_video_file` in `ts2mp4/ts2mp4.py` for consistency.
- Updated type hints and return values in `ts2mp4/initial_converter.py` and `tests/test_initial_converter.py` to reflect the new class.
