### PR TITLE
feat: Refactor audio re-encoder with StreamSource model

### DIFF
--- a/tests/test_audio_reencoder.py
+++ b/tests/test_audio_reencoder.py
@@ -6,20 +6,24 @@ import pytest
 from pytest_mock import MockerFixture
 
 from ts2mp4.audio_reencoder import (
-    _build_args_for_audio_streams,
-    _build_re_encode_args,
+    AudioReEncodedVideoFile,
+    StreamSourcesForAudioReEncoding,
+    _build_audio_convert_args,
+    _build_ffmpeg_args_from_stream_sources,
+    _build_stream_sources_for_audio_re_encoding,
     re_encode_mismatched_audio_streams,
 )
 from ts2mp4.ffmpeg import execute_ffmpeg
-from ts2mp4.media_info import MediaInfo, Stream, get_media_info
-from ts2mp4.video_file import VideoFile
+from ts2mp4.media_info import Stream, get_media_info
+from ts2mp4.video_file import ConversionType, StreamSource, StreamSources, VideoFile
 
 
 @pytest.mark.unit
-def test_build_re_encode_args(mocker: MockerFixture) -> None:
-    """Test that re-encode arguments are built correctly."""
+def test_build_audio_convert_args(mocker: MockerFixture) -> None:
+    """Test that audio convert arguments are built correctly."""
     mocker.patch("ts2mp4.audio_reencoder.is_libfdk_aac_available", return_value=False)
-    stream = Stream(
+    mock_stream_source = mocker.MagicMock(spec=StreamSource)
+    mock_stream_source.source_stream = Stream(
         index=1,
         codec_name="aac",
         codec_type="audio",
@@ -28,49 +32,49 @@ def test_build_re_encode_args(mocker: MockerFixture) -> None:
         profile="LC",
         bit_rate=192000,
     )
-    args = _build_re_encode_args(1, stream)
+    args = _build_audio_convert_args(mock_stream_source, 1)
     assert args == [
-        "-map",
-        "0:a:1",
-        "-codec:a:1",
+        "-codec:1",
         "aac",
-        "-ar:a:1",
+        "-ar:1",
         "48000",
-        "-ac:a:1",
+        "-ac:1",
         "2",
-        "-profile:a:1",
+        "-profile:1",
         "aac_low",
-        "-b:a:1",
+        "-b:1",
         "192000",
-        "-bsf:a:1",
+        "-bsf:1",
         "aac_adtstoasc",
     ]
 
 
 @pytest.mark.unit
-def test_build_re_encode_args_with_libfdk_aac(mocker: MockerFixture) -> None:
-    """Test that libfdk_aac is used when available."""
+def test_build_audio_convert_args_with_libfdk_aac(mocker: MockerFixture) -> None:
+    """Test that libfdk_aac is used when available for audio conversion."""
     mocker.patch("ts2mp4.audio_reencoder.is_libfdk_aac_available", return_value=True)
-    stream = Stream(
+    mock_stream_source = mocker.MagicMock(spec=StreamSource)
+    mock_stream_source.source_stream = Stream(
         index=1,
         codec_name="aac",
         codec_type="audio",
     )
-    args = _build_re_encode_args(1, stream)
+    args = _build_audio_convert_args(mock_stream_source, 1)
     assert "libfdk_aac" in args
 
 
 @pytest.mark.unit
-def test_build_re_encode_args_without_libfdk_aac(mocker: MockerFixture) -> None:
-    """Test that a warning is logged when libfdk_aac is not available."""
+def test_build_audio_convert_args_without_libfdk_aac(mocker: MockerFixture) -> None:
+    """Test that a warning is logged when libfdk_aac is not available for audio conversion."""
     mocker.patch("ts2mp4.audio_reencoder.is_libfdk_aac_available", return_value=False)
     mock_logger_warning = mocker.patch("ts2mp4.audio_reencoder.logger.warning")
-    stream = Stream(
+    mock_stream_source = mocker.MagicMock(spec=StreamSource)
+    mock_stream_source.source_stream = Stream(
         index=1,
         codec_name="aac",
         codec_type="audio",
     )
-    args = _build_re_encode_args(1, stream)
+    args = _build_audio_convert_args(mock_stream_source, 1)
     assert "aac" in args
     mock_logger_warning.assert_called_once_with(
         "libfdk_aac is not available. Falling back to the default AAC encoder."
@@ -78,120 +82,15 @@ def test_build_re_encode_args_without_libfdk_aac(mocker: MockerFixture) -> None:
 
 
 @pytest.mark.unit
-def test_build_re_encode_args_with_none_values() -> None:
-    """Test that re-encode arguments are built correctly with minimal stream info."""
-    stream = Stream(index=1, codec_name="aac", codec_type="audio")
-    args = _build_re_encode_args(1, stream)
-    assert args == ["-map", "0:a:1", "-codec:a:1", "aac", "-bsf:a:1", "aac_adtstoasc"]
-
-
-@pytest.mark.unit
-def test_build_args_for_audio_streams_no_mismatch(mocker: MockerFixture) -> None:
-    """Tests that copy arguments are generated when streams match."""
-    mock_original_video_file = mocker.MagicMock(spec=VideoFile)
-    mock_original_video_file.path = Path("original.ts")
-    mock_original_video_file.media_info = MediaInfo(
-        streams=[
-            Stream(codec_type="audio", index=0, codec_name="aac"),
-            Stream(codec_type="audio", index=1, codec_name="mp3"),
-        ]
+def test_build_audio_convert_args_with_none_values(mocker: MockerFixture) -> None:
+    """Test that audio convert arguments are built correctly with minimal stream info."""
+    mocker.patch("ts2mp4.audio_reencoder.is_libfdk_aac_available", return_value=False)
+    mock_stream_source = mocker.MagicMock(spec=StreamSource)
+    mock_stream_source.source_stream = Stream(
+        index=1, codec_name="aac", codec_type="audio"
     )
-
-    mock_encoded_video_file = mocker.MagicMock(spec=VideoFile)
-    mock_encoded_video_file.path = Path("encoded.mp4")
-    mock_encoded_video_file.media_info = MediaInfo(
-        streams=[
-            Stream(codec_type="audio", index=0, codec_name="aac"),
-            Stream(codec_type="audio", index=1, codec_name="mp3"),
-        ]
-    )
-
-    mocker.patch("ts2mp4.audio_reencoder.compare_stream_hashes", return_value=True)
-
-    result = _build_args_for_audio_streams(
-        mock_original_video_file, mock_encoded_video_file
-    )
-    assert result.ffmpeg_args == [
-        "-map",
-        "1:a:0",
-        "-codec:a:0",
-        "copy",
-        "-map",
-        "1:a:1",
-        "-codec:a:1",
-        "copy",
-    ]
-    assert result.copied_audio_stream_indices == [0, 1]
-
-
-@pytest.mark.unit
-def test_build_args_for_audio_streams_with_mismatch(mocker: MockerFixture) -> None:
-    """Tests that re-encode arguments are generated for mismatched streams."""
-    mock_original_video_file = mocker.MagicMock(spec=VideoFile)
-    mock_original_video_file.path = Path("original.ts")
-    mock_original_video_file.media_info = MediaInfo(
-        streams=[
-            Stream(codec_type="audio", index=0, codec_name="aac"),
-            Stream(codec_type="audio", index=1, codec_name="aac"),
-        ]
-    )
-
-    mock_encoded_video_file = mocker.MagicMock(spec=VideoFile)
-    mock_encoded_video_file.path = Path("encoded.mp4")
-    mock_encoded_video_file.media_info = MediaInfo(
-        streams=[
-            Stream(codec_type="audio", index=0, codec_name="aac"),
-            Stream(codec_type="audio", index=1, codec_name="aac"),
-        ]
-    )
-
-    mocker.patch(
-        "ts2mp4.audio_reencoder.compare_stream_hashes", side_effect=[True, False]
-    )
-
-    result = _build_args_for_audio_streams(
-        mock_original_video_file, mock_encoded_video_file
-    )
-    assert result.ffmpeg_args == [
-        "-map",
-        "1:a:0",
-        "-codec:a:0",
-        "copy",
-        "-map",
-        "0:a:1",
-        "-codec:a:1",
-        "aac",
-        "-bsf:a:1",
-        "aac_adtstoasc",
-    ]
-    assert result.copied_audio_stream_indices == [0]
-
-
-@pytest.mark.unit
-def test_build_args_for_audio_streams_unsupported_codec(
-    mocker: MockerFixture,
-) -> None:
-    """Tests that a NotImplementedError is raised for unsupported codecs."""
-    mock_original_video_file = mocker.MagicMock(spec=VideoFile)
-    mock_original_video_file.path = Path("original.ts")
-    mock_original_video_file.media_info = MediaInfo(
-        streams=[
-            Stream(codec_type="audio", index=0, codec_name="mp3"),
-        ]
-    )
-
-    mock_encoded_video_file = mocker.MagicMock(spec=VideoFile)
-    mock_encoded_video_file.path = Path("encoded.mp4")
-    mock_encoded_video_file.media_info = MediaInfo(
-        streams=[
-            Stream(codec_type="audio", index=0, codec_name="mp3"),
-        ]
-    )
-
-    mocker.patch("ts2mp4.audio_reencoder.compare_stream_hashes", return_value=False)
-
-    with pytest.raises(NotImplementedError):
-        _build_args_for_audio_streams(mock_original_video_file, mock_encoded_video_file)
+    args = _build_audio_convert_args(mock_stream_source, 1)
+    assert args == ["-codec:1", "aac", "-bsf:1", "aac_adtstoasc"]
 
 
 @pytest.mark.integration
@@ -216,15 +115,380 @@ def test_re_encode_mismatched_audio_streams_integration(
 
     # 2. Run the re-encoding function
     output_file = tmp_path / "output.mp4"
-    re_encode_mismatched_audio_streams(
+    result_video = re_encode_mismatched_audio_streams(
         original_file=VideoFile(path=ts_file),
         encoded_file=VideoFile(path=encoded_file_with_missing_stream),
         output_file=output_file,
     )
 
     # 3. Verify the output file
-    output_media_info = get_media_info(output_file)
+    assert result_video is not None
+    assert isinstance(result_video, AudioReEncodedVideoFile)
+    assert result_video.path == output_file
+
+    output_media_info = result_video.media_info
     original_media_info = get_media_info(ts_file)
 
     assert len(output_media_info.streams) == len(original_media_info.streams)
     # Further checks could be added here, e.g., comparing stream MD5s
+
+
+@pytest.mark.integration
+def test_re_encode_mismatched_audio_streams_no_re_encoding_needed(
+    tmp_path: Path, ts_file: Path
+) -> None:
+    """Tests that the function returns None when no re-encoding is needed."""
+    output_file = tmp_path / "output.mp4"
+
+    # By using the same file for original and encoded, we ensure that stream
+    # hashes match and no re-encoding should be triggered.
+    result_video = re_encode_mismatched_audio_streams(
+        original_file=VideoFile(path=ts_file),
+        encoded_file=VideoFile(path=ts_file),
+        output_file=output_file,
+    )
+
+    assert result_video is None
+    assert not output_file.exists()
+
+
+@pytest.mark.unit
+def test_build_stream_sources_for_audio_re_encoding_no_mismatch(
+    mocker: MockerFixture,
+) -> None:
+    """Tests that all streams are marked as COPIED when hashes match."""
+    mock_original_video_file = mocker.MagicMock(spec=VideoFile)
+    mock_original_video_file.path = Path("original.ts")
+    mock_original_video_file.media_info.streams = [
+        Stream(codec_type="video", index=0, codec_name="h264"),
+        Stream(codec_type="audio", index=1, codec_name="aac"),
+    ]
+
+    mock_encoded_video_file = mocker.MagicMock(spec=VideoFile)
+    mock_encoded_video_file.path = Path("encoded.mp4")
+    mock_encoded_video_file.media_info.streams = [
+        Stream(codec_type="video", index=0, codec_name="h265"),
+        Stream(codec_type="audio", index=1, codec_name="aac"),
+    ]
+
+    mocker.patch("ts2mp4.audio_reencoder.compare_stream_hashes", return_value=True)
+
+    stream_sources = _build_stream_sources_for_audio_re_encoding(
+        mock_original_video_file, mock_encoded_video_file
+    )
+
+    assert len(stream_sources) == 2
+
+    video_source = next(
+        s for s in stream_sources if s.source_stream.codec_type == "video"
+    )
+    assert video_source.source_video_file == mock_encoded_video_file
+    assert video_source.conversion_type == ConversionType.COPIED
+
+    audio_source = next(
+        s for s in stream_sources if s.source_stream.codec_type == "audio"
+    )
+    assert audio_source.source_video_file == mock_encoded_video_file
+    assert audio_source.conversion_type == ConversionType.COPIED
+
+
+@pytest.mark.unit
+def test_build_stream_sources_for_audio_re_encoding_with_mismatch(
+    mocker: MockerFixture,
+) -> None:
+    """Tests that mismatched audio streams are marked as CONVERTED."""
+    mock_original_video_file = mocker.MagicMock(spec=VideoFile)
+    mock_original_video_file.path = Path("original.ts")
+    mock_original_video_file.media_info.streams = [
+        Stream(codec_type="video", index=0, codec_name="h264"),
+        Stream(codec_type="audio", index=1, codec_name="aac"),
+        Stream(codec_type="audio", index=2, codec_name="aac"),
+    ]
+
+    mock_encoded_video_file = mocker.MagicMock(spec=VideoFile)
+    mock_encoded_video_file.path = Path("encoded.mp4")
+    mock_encoded_video_file.media_info.streams = [
+        Stream(codec_type="video", index=0, codec_name="h265"),
+        Stream(codec_type="audio", index=1, codec_name="aac"),
+        Stream(codec_type="audio", index=2, codec_name="aac"),
+    ]
+
+    mocker.patch(
+        "ts2mp4.audio_reencoder.compare_stream_hashes", side_effect=[True, False]
+    )
+
+    stream_sources = _build_stream_sources_for_audio_re_encoding(
+        mock_original_video_file, mock_encoded_video_file
+    )
+
+    assert len(stream_sources) == 3
+
+    video_source = stream_sources[0]
+    assert video_source.source_video_file == mock_encoded_video_file
+    assert video_source.conversion_type == ConversionType.COPIED
+
+    copied_audio_source = stream_sources[1]
+    assert copied_audio_source.source_video_file == mock_encoded_video_file
+    assert copied_audio_source.conversion_type == ConversionType.COPIED
+
+    converted_audio_source = stream_sources[2]
+    assert converted_audio_source.source_video_file == mock_original_video_file
+    assert converted_audio_source.conversion_type == ConversionType.CONVERTED
+
+
+@pytest.mark.unit
+def test_build_stream_sources_for_audio_re_encoding_missing_stream(
+    mocker: MockerFixture,
+) -> None:
+    """Tests that missing audio streams in encoded file are marked as CONVERTED."""
+    mock_original_video_file = mocker.MagicMock(spec=VideoFile)
+    mock_original_video_file.path = Path("original.ts")
+    mock_original_video_file.media_info.streams = [
+        Stream(codec_type="video", index=0, codec_name="h264"),
+        Stream(codec_type="audio", index=1, codec_name="aac"),
+    ]
+
+    mock_encoded_video_file = mocker.MagicMock(spec=VideoFile)
+    mock_encoded_video_file.path = Path("encoded.mp4")
+    mock_encoded_video_file.media_info.streams = [
+        Stream(codec_type="video", index=0, codec_name="h265")
+    ]
+
+    stream_sources = _build_stream_sources_for_audio_re_encoding(
+        mock_original_video_file, mock_encoded_video_file
+    )
+
+    assert len(stream_sources) == 2
+
+    converted_audio_source = stream_sources[1]
+    assert converted_audio_source.source_video_file == mock_original_video_file
+    assert converted_audio_source.conversion_type == ConversionType.CONVERTED
+
+
+@pytest.mark.unit
+def test_build_stream_sources_for_audio_re_encoding_extra_stream_in_encoded(
+    mocker: MockerFixture,
+) -> None:
+    """Tests that an error is raised if encoded file has more audio streams."""
+    mock_original_video_file = mocker.MagicMock(spec=VideoFile)
+    mock_original_video_file.path = Path("original.ts")
+    mock_original_video_file.media_info.streams = [
+        Stream(codec_type="video", index=0, codec_name="h264"),
+        Stream(codec_type="audio", index=1, codec_name="aac"),
+    ]
+
+    mock_encoded_video_file = mocker.MagicMock(spec=VideoFile)
+    mock_encoded_video_file.path = Path("encoded.mp4")
+    mock_encoded_video_file.media_info.streams = [
+        Stream(codec_type="video", index=0, codec_name="h265"),
+        Stream(codec_type="audio", index=1, codec_name="aac"),
+        Stream(codec_type="audio", index=2, codec_name="aac"),
+    ]
+
+    mocker.patch("ts2mp4.audio_reencoder.compare_stream_hashes", return_value=True)
+
+    with pytest.raises(RuntimeError):
+        _build_stream_sources_for_audio_re_encoding(
+            mock_original_video_file, mock_encoded_video_file
+        )
+
+
+@pytest.mark.unit
+def test_build_ffmpeg_args_from_stream_sources(mocker: MockerFixture) -> None:
+    """Tests that FFmpeg arguments are correctly built from a StreamSources object."""
+    mock_original_file = mocker.MagicMock(spec=VideoFile)
+    mock_original_file.path = Path("original.ts")
+    mock_encoded_file = mocker.MagicMock(spec=VideoFile)
+    mock_encoded_file.path = Path("encoded.mp4")
+
+    ss1 = mocker.MagicMock(spec=StreamSource)
+    ss1.source_video_file = mock_encoded_file
+    ss1.source_stream.index = 0
+    ss1.conversion_type = ConversionType.COPIED
+    ss1.source_stream.codec_type = "video"
+
+    ss2 = mocker.MagicMock(spec=StreamSource)
+    ss2.source_video_file = mock_encoded_file
+    ss2.source_stream.index = 1
+    ss2.conversion_type = ConversionType.COPIED
+    ss2.source_stream.codec_type = "audio"
+
+    ss3 = mocker.MagicMock(spec=StreamSource)
+    ss3.source_video_file = mock_original_file
+    ss3.source_stream.index = 2
+    ss3.conversion_type = ConversionType.CONVERTED
+    ss3.source_stream.codec_type = "audio"
+
+    stream_sources = mocker.MagicMock(spec=StreamSourcesForAudioReEncoding)
+    stream_sources.__iter__.return_value = [ss1, ss2, ss3]
+
+    mock_build_audio_convert_args = mocker.patch(
+        "ts2mp4.audio_reencoder._build_audio_convert_args",
+        return_value=["-codec:2", "libfdk_aac"],
+    )
+
+    output_path = Path("output.mp4")
+    args = _build_ffmpeg_args_from_stream_sources(stream_sources, output_path)
+
+    expected_args = [
+        "-hide_banner",
+        "-nostats",
+        "-fflags",
+        "+discardcorrupt",
+        "-y",
+        "-i",
+        "encoded.mp4",
+        "-i",
+        "original.ts",
+        "-map",
+        "0:0",  # Map video from encoded_file (input 0)
+        "-codec:0",
+        "copy",
+        "-map",
+        "0:1",  # Map first audio from encoded_file (input 0)
+        "-codec:1",
+        "copy",
+        "-map",
+        "1:2",  # Map second audio from original_file (input 1)
+        "-codec:2",  # Mocked return value
+        "libfdk_aac",
+        "-f",
+        "mp4",
+        "output.mp4",
+    ]
+
+    assert args == expected_args
+    mock_build_audio_convert_args.assert_called_once_with(ss3, 2)
+
+
+@pytest.mark.unit
+def test_stream_sources_for_audio_re_encoding_validation_success(
+    mocker: MockerFixture,
+) -> None:
+    """Tests that StreamSourcesForAudioReEncoding can be created with valid data."""
+    mock_original_file = mocker.MagicMock(spec=VideoFile)
+    mock_encoded_file = mocker.MagicMock(spec=VideoFile)
+
+    valid_sources = StreamSources(
+        [
+            mocker.MagicMock(
+                spec=StreamSource,
+                source_video_file=mock_encoded_file,
+                conversion_type=ConversionType.COPIED,
+                source_stream=mocker.MagicMock(spec=Stream, codec_type="video"),
+            ),
+            mocker.MagicMock(
+                spec=StreamSource,
+                source_video_file=mock_original_file,
+                conversion_type=ConversionType.CONVERTED,
+                source_stream=mocker.MagicMock(spec=Stream, codec_type="audio"),
+            ),
+        ]
+    )
+    # This should not raise an error
+    StreamSourcesForAudioReEncoding(valid_sources)
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    "modifier, error_message",
+    [
+        ("no_video", "At least one video stream is required."),
+        ("video_not_copied", "All video streams must be copied."),
+        (
+            "video_from_original",
+            "All copied streams must come from the same encoded file.",
+        ),
+        ("no_audio", "At least one audio stream is required."),
+        (
+            "copied_audio_from_original",
+            "All copied streams must come from the same encoded file.",
+        ),
+        (
+            "converted_audio_from_encoded",
+            "Original and encoded files cannot be the same when re-encoding.",
+        ),
+        ("unsupported_stream", "Only video and audio streams are supported."),
+        (
+            "only_converted",
+            "At least one video stream is required.",
+        ),  # This now fails at the video check
+        (
+            "converted_from_multiple",
+            "All converted streams must come from the same original file.",
+        ),
+    ],
+)
+def test_stream_sources_for_audio_re_encoding_validation_failures(
+    modifier: str, error_message: str, mocker: MockerFixture
+) -> None:
+    """Tests the validation rules in StreamSourcesForAudioReEncoding.__new__."""
+    mock_original_file = mocker.MagicMock(spec=VideoFile)
+    mock_encoded_file = mocker.MagicMock(spec=VideoFile)
+
+    # Create a base valid list of sources
+    sources = [
+        mocker.MagicMock(
+            spec=StreamSource,
+            source_video_file=mock_encoded_file,
+            conversion_type=ConversionType.COPIED,
+            source_stream=mocker.MagicMock(spec=Stream, codec_type="video"),
+        ),
+        mocker.MagicMock(
+            spec=StreamSource,
+            source_video_file=mock_encoded_file,
+            conversion_type=ConversionType.COPIED,
+            source_stream=mocker.MagicMock(spec=Stream, codec_type="audio"),
+        ),
+        mocker.MagicMock(
+            spec=StreamSource,
+            source_video_file=mock_original_file,
+            conversion_type=ConversionType.CONVERTED,
+            source_stream=mocker.MagicMock(spec=Stream, codec_type="audio"),
+        ),
+    ]
+
+    # Modify the sources based on the test case
+    if modifier == "no_video":
+        sources = [s for s in sources if s.source_stream.codec_type != "video"]
+    elif modifier == "video_not_copied":
+        sources[0].conversion_type = ConversionType.CONVERTED
+    elif modifier == "video_from_original":
+        sources[0].source_video_file = mock_original_file
+    elif modifier == "no_audio":
+        sources = [s for s in sources if s.source_stream.codec_type != "audio"]
+    elif modifier == "copied_audio_from_original":
+        sources.append(
+            mocker.MagicMock(
+                spec=StreamSource,
+                source_video_file=mock_original_file,  # Invalid
+                conversion_type=ConversionType.COPIED,
+                source_stream=mocker.MagicMock(spec=Stream, codec_type="audio"),
+            )
+        )
+    elif modifier == "converted_audio_from_encoded":
+        sources[2].source_video_file = mock_encoded_file  # Invalid
+    elif modifier == "unsupported_stream":
+        sources.append(
+            mocker.MagicMock(
+                spec=StreamSource,
+                source_video_file=mock_original_file,
+                conversion_type=ConversionType.CONVERTED,
+                source_stream=mocker.MagicMock(spec=Stream, codec_type="subtitle"),
+            )
+        )
+    elif modifier == "only_converted":
+        sources = [sources[2]]
+    elif modifier == "converted_from_multiple":
+        mock_another_original = mocker.MagicMock(spec=VideoFile)
+        sources.append(
+            mocker.MagicMock(
+                spec=StreamSource,
+                source_video_file=mock_another_original,
+                conversion_type=ConversionType.CONVERTED,
+                source_stream=mocker.MagicMock(spec=Stream, codec_type="audio"),
+            )
+        )
+
+    with pytest.raises(ValueError, match=error_message):
+        StreamSourcesForAudioReEncoding(StreamSources(sources))

--- a/ts2mp4/audio_reencoder.py
+++ b/ts2mp4/audio_reencoder.py
@@ -2,28 +2,162 @@
 
 import itertools
 from pathlib import Path
-from typing import NamedTuple
+from typing import Optional
 
 from logzero import logger
+from typing_extensions import Self
 
 from .ffmpeg import execute_ffmpeg, is_libfdk_aac_available
-from .media_info import Stream
 from .quality_check import get_audio_quality_metrics
-from .stream_integrity import compare_stream_hashes, verify_streams
-from .video_file import VideoFile
+from .stream_integrity import compare_stream_hashes, verify_copied_streams
+from .video_file import (
+    ConversionType,
+    ConvertedVideoFile,
+    StreamSource,
+    StreamSources,
+    VideoFile,
+)
 
 
-class AudioStreamArgs(NamedTuple):
-    """A tuple containing FFmpeg arguments and indices of copied/re-encoded audio streams."""
+class StreamSourcesForAudioReEncoding(StreamSources):
+    """Represents the stream sources for the audio re-encoding."""
 
-    ffmpeg_args: list[str]
-    copied_audio_stream_indices: list[int]
-    re_encoded_audio_stream_indices: list[int]
+    def __new__(cls, stream_sources: StreamSources) -> Self:
+        """Initialize and validate the StreamSourcesForAudioReEncoding."""
+        video_sources = stream_sources.video_stream_sources
+        audio_sources = stream_sources.audio_stream_sources
+
+        # 1. Check for unsupported stream types
+        if len(stream_sources) != len(video_sources) + len(audio_sources):
+            raise ValueError("Only video and audio streams are supported.")
+
+        # 2. Check for presence of video and audio streams
+        if not video_sources:
+            raise ValueError("At least one video stream is required.")
+        if not audio_sources:
+            raise ValueError("At least one audio stream is required.")
+
+        # 3. Check video stream properties
+        if not all(s.conversion_type == ConversionType.COPIED for s in video_sources):
+            raise ValueError("All video streams must be copied.")
+
+        # 4. Grouping and source validation
+        copied_sources = [
+            s for s in stream_sources if s.conversion_type == ConversionType.COPIED
+        ]
+        converted_sources = [
+            s for s in stream_sources if s.conversion_type == ConversionType.CONVERTED
+        ]
+
+        if not copied_sources:
+            # This should be unreachable if there's at least one video stream and it's copied.
+            raise ValueError("At least one stream must be copied.")
+
+        encoded_files = {s.source_video_file for s in copied_sources}
+        if len(encoded_files) != 1:
+            raise ValueError("All copied streams must come from the same encoded file.")
+
+        if converted_sources:
+            if not all(
+                s.source_stream.codec_type == "audio" for s in converted_sources
+            ):
+                raise ValueError("Only audio streams can be converted.")
+
+            original_files = {s.source_video_file for s in converted_sources}
+            if len(original_files) != 1:
+                raise ValueError(
+                    "All converted streams must come from the same original file."
+                )
+
+            encoded_file = encoded_files.pop()
+            original_file = original_files.pop()
+            if original_file == encoded_file:
+                raise ValueError(
+                    "Original and encoded files cannot be the same when re-encoding."
+                )
+
+        return super().__new__(cls, stream_sources)
 
 
-def _build_re_encode_args(
-    audio_stream_index: int, original_audio_stream: Stream
+class AudioReEncodedVideoFile(ConvertedVideoFile):
+    """Represents a ConvertedVideoFile that has undergone audio re-encoding."""
+
+    stream_sources: StreamSourcesForAudioReEncoding
+
+
+def _build_stream_sources_for_audio_re_encoding(
+    original_file: VideoFile, encoded_file: VideoFile
+) -> StreamSourcesForAudioReEncoding:
+    """Build the stream sources for audio re-encoding."""
+    stream_sources_list = []
+
+    # Video streams are always copied from the encoded file
+    video_streams = [
+        s for s in encoded_file.media_info.streams if s.codec_type == "video"
+    ]
+    for stream in video_streams:
+        stream_sources_list.append(
+            StreamSource(
+                source_video_file=encoded_file,
+                source_stream_index=stream.index,
+                conversion_type=ConversionType.COPIED,
+            )
+        )
+
+    # Determine whether to copy or re-encode audio streams
+    original_audio_streams = [
+        s for s in original_file.media_info.streams if s.codec_type == "audio"
+    ]
+    encoded_audio_streams = [
+        s for s in encoded_file.media_info.streams if s.codec_type == "audio"
+    ]
+
+    for original_audio_stream, encoded_audio_stream in itertools.zip_longest(
+        original_audio_streams, encoded_audio_streams
+    ):
+        if original_audio_stream is None:
+            raise RuntimeError(
+                f"Encoded file {encoded_file.path.name} has more audio streams "
+                f"than the original {original_file.path.name}."
+            )
+
+        should_re_encode = encoded_audio_stream is None or not compare_stream_hashes(
+            input_video=original_file,
+            output_video=encoded_file,
+            input_stream=original_audio_stream,
+            output_stream=encoded_audio_stream,
+        )
+
+        if should_re_encode:
+            if original_audio_stream.codec_name != "aac":
+                raise NotImplementedError(
+                    "Re-encoding is currently only supported for aac audio codec."
+                )
+            stream_sources_list.append(
+                StreamSource(
+                    source_video_file=original_file,
+                    source_stream_index=original_audio_stream.index,
+                    conversion_type=ConversionType.CONVERTED,
+                )
+            )
+        else:
+            stream_sources_list.append(
+                StreamSource(
+                    source_video_file=encoded_file,
+                    source_stream_index=encoded_audio_stream.index,
+                    conversion_type=ConversionType.COPIED,
+                )
+            )
+
+    return StreamSourcesForAudioReEncoding(StreamSources(stream_sources_list))
+
+
+def _build_audio_convert_args(
+    stream_source: StreamSource, output_stream_index: int
 ) -> list[str]:
+    """Build FFmpeg arguments for converting an audio stream."""
+    original_audio_stream = stream_source.source_stream
+
     codec_name = str(original_audio_stream.codec_name)
     if original_audio_stream.codec_name == "aac":
         if is_libfdk_aac_available():
@@ -33,23 +167,21 @@ def _build_re_encode_args(
                 "libfdk_aac is not available. Falling back to the default AAC encoder."
             )
 
-    re_encode_args = [
-        "-map",
-        f"0:a:{audio_stream_index}",
-        f"-codec:a:{audio_stream_index}",
+    convert_args = [
+        f"-codec:{output_stream_index}",
         codec_name,
     ]
     if original_audio_stream.sample_rate is not None:
-        re_encode_args.extend(
+        convert_args.extend(
             [
-                f"-ar:a:{audio_stream_index}",
+                f"-ar:{output_stream_index}",
                 str(original_audio_stream.sample_rate),
             ]
         )
     if original_audio_stream.channels is not None:
-        re_encode_args.extend(
+        convert_args.extend(
             [
-                f"-ac:a:{audio_stream_index}",
+                f"-ac:{output_stream_index}",
                 str(original_audio_stream.channels),
             ]
         )
@@ -58,144 +190,31 @@ def _build_re_encode_args(
         profile = profile_map.get(
             original_audio_stream.profile, original_audio_stream.profile
         )
-        re_encode_args.extend(
+        convert_args.extend(
             [
-                f"-profile:a:{audio_stream_index}",
+                f"-profile:{output_stream_index}",
                 profile,
             ]
         )
     if original_audio_stream.bit_rate is not None:
-        re_encode_args.extend(
+        convert_args.extend(
             [
-                f"-b:a:{audio_stream_index}",
+                f"-b:{output_stream_index}",
                 str(original_audio_stream.bit_rate),
             ]
         )
-    re_encode_args.extend([f"-bsf:a:{audio_stream_index}", "aac_adtstoasc"])
-    return re_encode_args
+    convert_args.extend([f"-bsf:{output_stream_index}", "aac_adtstoasc"])
+    return convert_args
 
 
-def _build_args_for_audio_streams(
-    original_file: VideoFile, encoded_file: VideoFile
-) -> AudioStreamArgs:
-    """Build FFmpeg arguments and identify copied audio streams.
-
-    It assumes that the order of audio streams is preserved between the
-    original and encoded files.
-    """
-    original_media_info = original_file.media_info
-    encoded_media_info = encoded_file.media_info
-
-    original_audio_streams = [
-        stream for stream in original_media_info.streams if stream.codec_type == "audio"
-    ]
-    encoded_audio_streams = [
-        stream for stream in encoded_media_info.streams if stream.codec_type == "audio"
-    ]
-
-    ffmpeg_args = []
-    copied_audio_stream_indices = []
-    re_encoded_audio_stream_indices = []
-    for audio_stream_index, (original_audio_stream, encoded_audio_stream) in enumerate(
-        itertools.zip_longest(original_audio_streams, encoded_audio_streams)
-    ):
-        if original_audio_stream is None:
-            # Unexpected: Original file has fewer audio streams than expected.
-            raise RuntimeError(
-                f"Encoded file {encoded_file.path.name} has more audio streams than the original {original_file.path.name}."
-            )
-
-        integrity_check_passes = False
-        if encoded_audio_stream is not None:
-            integrity_check_passes = compare_stream_hashes(
-                input_video=original_file,
-                output_video=encoded_file,
-                input_stream=original_audio_stream,
-                output_stream=encoded_audio_stream,
-            )
-
-        if not integrity_check_passes:
-            if original_audio_stream.codec_name is None:
-                # Unexpected: Original file's audio stream lacks a codec name.
-                raise RuntimeError(
-                    f"Original audio stream at index {audio_stream_index} has no codec name."
-                )
-            if original_audio_stream.codec_name != "aac":
-                raise NotImplementedError(
-                    "Re-encoding is currently only supported for aac audio codec."
-                )
-
-            logger.warning(
-                f"Re-encoding audio stream at index {audio_stream_index} "
-                f"from {original_file.path.name} due to mismatch or absence in {encoded_file.path.name}."
-            )
-
-            ffmpeg_args.extend(
-                _build_re_encode_args(audio_stream_index, original_audio_stream)
-            )
-            re_encoded_audio_stream_indices.append(audio_stream_index)
-        else:
-            ffmpeg_args.extend(
-                [
-                    "-map",
-                    f"1:a:{audio_stream_index}",  # Use encoded audio stream
-                    f"-codec:a:{audio_stream_index}",
-                    "copy",  # Copy codec without re-encoding
-                ]
-            )
-            copied_audio_stream_indices.append(audio_stream_index)
-
-    return AudioStreamArgs(
-        ffmpeg_args=ffmpeg_args,
-        copied_audio_stream_indices=copied_audio_stream_indices,
-        re_encoded_audio_stream_indices=re_encoded_audio_stream_indices,
-    )
-
-
-def re_encode_mismatched_audio_streams(
-    original_file: VideoFile, encoded_file: VideoFile, output_file: Path
-) -> None:
-    """Re-encodes mismatched audio streams from an original file to a new output file.
-
-    This function identifies audio streams that are either missing in the encoded
-    file or have different content compared to the original file. It then
-    generates a new video file by:
-    - Copying the video stream from the already encoded file.
-    - Copying matching audio streams from the encoded file.
-    - Re-encoding mismatched or missing audio streams from the original file
-      using their original codecs.
-
-    Args:
-    ----
-        original_file: The VideoFile object for the original source file (e.g., .ts).
-        encoded_file: The VideoFile object for the file that has been encoded but may have
-                      audio stream issues.
-        output_file: The path where the corrected output file will be saved.
-    """
-
-    def _verify_integrity(
-        copied_audio_stream_indices: list[int],
-    ) -> None:
-        """Verify the integrity of streams after re-encoding."""
-        logger.info(f"Verifying stream integrity for {output_file.name}")
-
-        verify_streams(encoded_file, VideoFile(path=output_file), "video")
-        verify_streams(
-            encoded_file,
-            VideoFile(path=output_file),
-            "audio",
-            type_specific_stream_indices=copied_audio_stream_indices,
-        )
-
-        logger.info("Stream integrity verified successfully.")
-
-    audio_stream_args = _build_args_for_audio_streams(
-        original_file=original_file, encoded_file=encoded_file
-    )
-
-    if not audio_stream_args.ffmpeg_args:
-        logger.info("No audio streams require re-encoding.")
-        return
+def _build_ffmpeg_args_from_stream_sources(
+    stream_sources: StreamSourcesForAudioReEncoding,
+    output_path: Path,
+) -> list[str]:
+    """Build FFmpeg arguments from a StreamSources object."""
+    # Create a unique, ordered list of input files and a mapping to their index
+    input_files = list(dict.fromkeys(s.source_video_file for s in stream_sources))
+    input_file_map = {file: i for i, file in enumerate(input_files)}
 
     ffmpeg_args = [
         "-hide_banner",
@@ -203,38 +222,97 @@ def re_encode_mismatched_audio_streams(
         "-fflags",
         "+discardcorrupt",
         "-y",
-        "-i",
-        str(original_file.path),
-        "-i",
-        str(encoded_file.path),
-        # for video streams
-        "-map",
-        "1:v",  # Use video stream from encoded_file
-        "-codec:v",
-        "copy",  # Copy video codec without re-encoding
-        # for audio streams
-        *audio_stream_args.ffmpeg_args,
-        # # for subtitles
-        # "-map",
-        # "1:s?",  # Use subtitle streams from encoded_file if available
-        # "-codec:s",
-        # "copy",  # Copy subtitle codec without re-encoding
-        # output file
-        "-f",
-        "mp4",
-        str(output_file),
     ]
+
+    # Add -i arguments for each unique input file
+    for file in input_files:
+        ffmpeg_args.extend(["-i", str(file.path)])
+
+    # Add -map and codec arguments for each stream
+    for i, source in enumerate(stream_sources):
+        input_index = input_file_map[source.source_video_file]
+
+        # Add map argument using the original stream index from the source file
+        ffmpeg_args.extend(["-map", f"{input_index}:{source.source_stream.index}"])
+
+        # Add codec arguments using the global output stream index
+        if source.conversion_type == ConversionType.COPIED:
+            ffmpeg_args.extend([f"-codec:{i}", "copy"])
+        elif source.source_stream.codec_type == "audio":
+            ffmpeg_args.extend(_build_audio_convert_args(source, i))
+        else:
+            # This path should be unreachable due to validation in StreamSourcesForAudioReEncoding
+            raise ValueError(
+                f"Invalid conversion requested for stream type '{source.source_stream.codec_type}'."
+            )
+
+    # Add final output arguments
+    ffmpeg_args.extend(["-f", "mp4", str(output_path)])
+
+    return ffmpeg_args
+
+
+def re_encode_mismatched_audio_streams(
+    original_file: VideoFile, encoded_file: VideoFile, output_file: Path
+) -> Optional[AudioReEncodedVideoFile]:
+    """Re-encodes mismatched audio streams from an original file to a new output file.
+
+    This function identifies audio streams that are either missing in the encoded
+    file or have different content compared to the original file. It then
+    generates a new video file by:
+    - Copying the video stream from the already encoded file.
+    - Copying matching audio streams from the encoded file.
+    - Re-encoding mismatched or missing audio streams from the original file.
+
+    Args:
+    ----
+        original_file: The VideoFile object for the original source file (e.g., .ts).
+        encoded_file: The VideoFile object for the file that has been encoded but may have
+                      audio stream issues.
+        output_file: The path where the corrected output file will be saved.
+
+    Returns
+    -------
+        An AudioReEncodedVideoFile object if re-encoding was performed, otherwise None.
+    """
+    stream_sources = _build_stream_sources_for_audio_re_encoding(
+        original_file=original_file, encoded_file=encoded_file
+    )
+
+    # If all audio streams are to be copied, no re-encoding is needed.
+    if not any(s.conversion_type == ConversionType.CONVERTED for s in stream_sources):
+        logger.info("No audio streams require re-encoding. Skipping.")
+        return None
+
+    ffmpeg_args = _build_ffmpeg_args_from_stream_sources(
+        stream_sources=stream_sources,
+        output_path=output_file,
+    )
 
     # Execute the FFmpeg command
     result = execute_ffmpeg(ffmpeg_args)
     if result.returncode != 0:
         raise RuntimeError(f"ffmpeg failed with return code {result.returncode}")
 
-    _verify_integrity(
-        copied_audio_stream_indices=audio_stream_args.copied_audio_stream_indices,
+    re_encoded_video_file = AudioReEncodedVideoFile(
+        path=output_file, stream_sources=stream_sources
     )
 
-    for audio_stream_index in audio_stream_args.re_encoded_audio_stream_indices:
+    # Verify integrity of copied streams
+    verify_copied_streams(re_encoded_video_file)
+
+    # Get quality metrics for re-encoded streams
+    audio_sources = [
+        s
+        for s in re_encoded_video_file.stream_sources
+        if s.source_stream.codec_type == "audio"
+    ]
+    re_encoded_audio_indices = [
+        i
+        for i, s in enumerate(audio_sources)
+        if s.conversion_type == ConversionType.CONVERTED
+    ]
+    for audio_stream_index in re_encoded_audio_indices:
         metrics = get_audio_quality_metrics(
             original_file=original_file.path,
             re_encoded_file=output_file,
@@ -250,3 +328,5 @@ def re_encode_mismatched_audio_streams(
                 logger.info(
                     f"Audio quality for stream {audio_stream_index}: {', '.join(log_parts)}"
                 )
+
+    return re_encoded_video_file


### PR DESCRIPTION
Refactor the `re_encode_mismatched_audio_streams` function and its
helpers to use the `StreamSource` data model, following the design
pattern established in `initial_converter.py`.

This change introduces a more structured and declarative approach to
handling stream selection for audio re-encoding, significantly
improving readability, maintainability, and testability.

Key changes:
- Refactor to use the `StreamSource` data model, making the plan for
  what to do with each stream declarative and explicit.
- Use the existing `ConversionType.CONVERTED` to represent audio
  re-encoding, avoiding unnecessary extension of the enum and keeping
  it generic.
- Introduce `StreamSourcesForAudioReEncoding` and
  `AudioReEncodedVideoFile`, specialized data models that enforce
  validation rules specific to the audio re-encoding context.
- Replace complex procedural logic with:
  - `_build_stream_sources_for_audio_re_encoding`: A function that
    determines the plan of action (copy/convert) and returns a
    `StreamSourcesForAudioReEncoding` object.
  - `_build_audio_convert_args`: A new helper to build FFmpeg arguments
    for audio conversion, encapsulating the logic for codec selection.
  - `_build_ffmpeg_args_from_stream_sources`: A dispatcher function that
    generates FFmpeg arguments by calling the appropriate helpers.
- Overhaul the test suite to match the new design, removing obsolete
  tests and adding granular unit tests for the new components and their
  validation logic.
