### PR TITLE
refactor(quality_check): pass ConvertedVideoFile to get_audio_quality_metrics

### DIFF
--- a/tests/test_quality_check.py
+++ b/tests/test_quality_check.py
@@ -2,6 +2,7 @@
 
 from pathlib import Path
 from typing import Union
+from unittest.mock import MagicMock
 
 import pytest
 from pytest_mock import MockerFixture
@@ -10,6 +11,13 @@ from ts2mp4.quality_check import (
     AudioQualityMetrics,
     get_audio_quality_metrics,
     parse_audio_quality_metrics,
+)
+from ts2mp4.video_file import (
+    ConversionType,
+    ConvertedVideoFile,
+    StreamSource,
+    StreamSources,
+    VideoFile,
 )
 
 
@@ -71,55 +79,145 @@ def test_parse_audio_quality_metrics(
 
 
 @pytest.mark.unit
-@pytest.mark.parametrize(
-    "ffmpeg_stderr, expected_metrics",
-    [
-        (
-            "[Parsed_apsnr_0 @ 0x123] PSNR ch0: 30.00 dB\n[Parsed_asdr_1 @ 0x456] SDR ch0: 25.00 dB",
-            AudioQualityMetrics(apsnr=30.00, asdr=25.00),
-        ),
-        (
-            "Some other ffmpeg output\n[Parsed_apsnr_0 @ 0x123] PSNR ch0: inf dB",
-            AudioQualityMetrics(apsnr=float("inf"), asdr=None),
-        ),
-        (
-            "Error: something went wrong",
-            None,
-        ),
-    ],
-)
-def test_get_audio_quality_metrics_unit(
-    mocker: MockerFixture,
-    ffmpeg_stderr: str,
-    expected_metrics: Union[AudioQualityMetrics, None],
-) -> None:
+def test_get_audio_quality_metrics_unit(mocker: MockerFixture) -> None:
     """Test the audio quality metrics calculation unit."""
     mock_execute_ffmpeg = mocker.patch("ts2mp4.quality_check.execute_ffmpeg")
-    mock_execute_ffmpeg.return_value.returncode = 0 if expected_metrics else 1
-    mock_execute_ffmpeg.return_value.stderr = ffmpeg_stderr
-
-    metrics = get_audio_quality_metrics(
-        original_file=Path("dummy_original.ts"),
-        re_encoded_file=Path("dummy_re_encoded.mp4"),
-        audio_stream_index=0,
+    mock_execute_ffmpeg.return_value.returncode = 0
+    mock_execute_ffmpeg.return_value.stderr = (
+        "[Parsed_apsnr_0 @ 0x123] PSNR ch0: 30.00 dB\n"
+        "[Parsed_asdr_1 @ 0x456] SDR ch0: 25.00 dB"
     )
 
-    assert metrics == expected_metrics
+    mock_converted_file = MagicMock(spec=ConvertedVideoFile)
+    mock_stream1 = MagicMock(index=0, codec_type="audio")
+    mock_stream2 = MagicMock(index=1, codec_type="video")
+    mock_stream3 = MagicMock(index=2, codec_type="audio")
+
+    mock_source1 = MagicMock(
+        conversion_type=ConversionType.CONVERTED,
+        source_stream=MagicMock(index=0),
+        source_video_file=MagicMock(path="original.ts"),
+    )
+    mock_source2 = MagicMock(conversion_type=ConversionType.COPIED)
+    mock_source3 = MagicMock(
+        conversion_type=ConversionType.CONVERTED,
+        source_stream=MagicMock(index=1),
+        source_video_file=MagicMock(path="original.ts"),
+    )
+
+    mock_converted_file.stream_with_sources = [
+        (mock_stream1, mock_source1),
+        (mock_stream2, mock_source2),
+        (mock_stream3, mock_source3),
+    ]
+    mock_converted_file.path = "converted.mp4"
+
+    metrics = get_audio_quality_metrics(mock_converted_file)
+
+    assert len(metrics) == 2
+    assert 0 in metrics
+    assert 2 in metrics
+    assert metrics[0] == AudioQualityMetrics(apsnr=30.00, asdr=25.00)
+    assert metrics[2] == AudioQualityMetrics(apsnr=30.00, asdr=25.00)
+    assert mock_execute_ffmpeg.call_count == 2
+
+
+@pytest.mark.unit
+def test_get_audio_quality_metrics_partial_failure(mocker: MockerFixture) -> None:
+    """Test quality metrics calculation with a partial FFmpeg failure."""
+    mock_execute_ffmpeg = mocker.patch("ts2mp4.quality_check.execute_ffmpeg")
+
+    # Simulate failure for the first call, success for the second
+    mock_result_fail = MagicMock(returncode=1, stderr="Error")
+    mock_result_success = MagicMock(
+        returncode=0,
+        stderr=(
+            "[Parsed_apsnr_0 @ 0x123] PSNR ch0: 30.00 dB\n"
+            "[Parsed_asdr_1 @ 0x456] SDR ch0: 25.00 dB"
+        ),
+    )
+    mock_execute_ffmpeg.side_effect = [mock_result_fail, mock_result_success]
+
+    mock_converted_file = MagicMock(spec=ConvertedVideoFile)
+    mock_stream1 = MagicMock(index=0, codec_type="audio")
+    mock_stream2 = MagicMock(index=2, codec_type="audio")
+
+    mock_source1 = MagicMock(
+        conversion_type=ConversionType.CONVERTED,
+        source_stream=MagicMock(index=0),
+        source_video_file=MagicMock(path="original.ts"),
+    )
+    mock_source2 = MagicMock(
+        conversion_type=ConversionType.CONVERTED,
+        source_stream=MagicMock(index=1),
+        source_video_file=MagicMock(path="original.ts"),
+    )
+
+    mock_converted_file.stream_with_sources = [
+        (mock_stream1, mock_source1),
+        (mock_stream2, mock_source2),
+    ]
+    mock_converted_file.path = "converted.mp4"
+
+    metrics = get_audio_quality_metrics(mock_converted_file)
+
+    assert len(metrics) == 1
+    assert 2 in metrics
+    assert metrics[2] == AudioQualityMetrics(apsnr=30.00, asdr=25.00)
+    assert mock_execute_ffmpeg.call_count == 2
+
+
+@pytest.mark.unit
+def test_get_audio_quality_metrics_no_metrics_parsed(mocker: MockerFixture) -> None:
+    """Test quality metrics calculation when no metrics are parsed from output."""
+    mock_execute_ffmpeg = mocker.patch("ts2mp4.quality_check.execute_ffmpeg")
+    mock_execute_ffmpeg.return_value.returncode = 0
+    mock_execute_ffmpeg.return_value.stderr = "No metrics here"
+
+    mock_converted_file = MagicMock(spec=ConvertedVideoFile)
+    mock_stream1 = MagicMock(index=0, codec_type="audio")
+    mock_source1 = MagicMock(
+        conversion_type=ConversionType.CONVERTED,
+        source_stream=MagicMock(index=0),
+        source_video_file=MagicMock(path="original.ts"),
+    )
+    mock_converted_file.stream_with_sources = [(mock_stream1, mock_source1)]
+    mock_converted_file.path = "converted.mp4"
+
+    metrics = get_audio_quality_metrics(mock_converted_file)
+
+    assert len(metrics) == 0
 
 
 @pytest.mark.integration
-@pytest.mark.parametrize("audio_stream_index", [0, 1])
-def test_get_audio_quality_metrics_integration(
-    ts_file: Path, audio_stream_index: int
-) -> None:
+def test_get_audio_quality_metrics_integration(ts_file: Path) -> None:
     """Test get_audio_quality_metrics with a real video file."""
-    metrics = get_audio_quality_metrics(
-        original_file=ts_file,
-        re_encoded_file=ts_file,
-        audio_stream_index=audio_stream_index,
+    video_file = VideoFile(path=ts_file)
+    stream_sources = []
+    for stream in video_file.media_info.streams:
+        stream_sources.append(
+            StreamSource(
+                source_video_file=video_file,
+                source_stream_index=stream.index,
+                conversion_type=(
+                    ConversionType.CONVERTED
+                    if stream.codec_type == "audio"
+                    else ConversionType.COPIED
+                ),
+            )
+        )
+
+    converted_file = ConvertedVideoFile(
+        path=ts_file, stream_sources=StreamSources(stream_sources)
     )
-    assert metrics is not None
-    assert metrics.apsnr is not None
-    assert metrics.asdr is not None
-    assert metrics.apsnr > 0  # APSNR should be positive for identical files
-    assert metrics.asdr > 0  # ASDR should be positive for identical files
+
+    metrics_dict = get_audio_quality_metrics(converted_file)
+
+    assert len(metrics_dict) == len(video_file.valid_audio_streams)
+    for stream_index, metrics in metrics_dict.items():
+        assert stream_index in [s.index for s in video_file.valid_audio_streams]
+        assert metrics is not None
+        assert metrics.apsnr is not None
+        assert metrics.asdr is not None
+        assert metrics.apsnr > 0  # APSNR should be positive for identical files
+        assert metrics.asdr > 0  # ASDR should be positive for identical files

--- a/ts2mp4/audio_reencoder.py
+++ b/ts2mp4/audio_reencoder.py
@@ -300,31 +300,16 @@ def re_encode_mismatched_audio_streams(
     verify_copied_streams(re_encoded_video_file)
 
     # Get quality metrics for re-encoded streams
-    audio_sources = [
-        s
-        for s in re_encoded_video_file.stream_sources
-        if s.source_stream.codec_type == "audio"
-    ]
-    re_encoded_audio_indices = [
-        i
-        for i, s in enumerate(audio_sources)
-        if s.conversion_type == ConversionType.CONVERTED
-    ]
-    for audio_stream_index in re_encoded_audio_indices:
-        metrics = get_audio_quality_metrics(
-            original_file=original_file.path,
-            re_encoded_file=output_file,
-            audio_stream_index=audio_stream_index,
-        )
-        if metrics:
-            log_parts = []
-            if metrics.apsnr is not None:
-                log_parts.append(f"APSNR={metrics.apsnr:.2f}dB")
-            if metrics.asdr is not None:
-                log_parts.append(f"ASDR={metrics.asdr:.2f}dB")
-            if log_parts:
-                logger.info(
-                    f"Audio quality for stream {audio_stream_index}: {', '.join(log_parts)}"
-                )
+    quality_metrics = get_audio_quality_metrics(re_encoded_video_file)
+    for stream_index, metrics in quality_metrics.items():
+        log_parts = []
+        if metrics.apsnr is not None:
+            log_parts.append(f"APSNR={metrics.apsnr:.2f}dB")
+        if metrics.asdr is not None:
+            log_parts.append(f"ASDR={metrics.asdr:.2f}dB")
+        if log_parts:
+            logger.info(
+                f"Audio quality for stream {stream_index}: {', '.join(log_parts)}"
+            )
 
     return re_encoded_video_file


### PR DESCRIPTION
Refactors `get_audio_quality_metrics` to accept a single `ConvertedVideoFile` object instead of multiple path and index arguments.

This aligns the function signature with other utilities like `verify_copied_streams`, creating a more consistent and user-friendly API. The function now automatically calculates metrics for all converted audio streams within the file.

The call site in `audio_reencoder.py` and the corresponding unit and integration tests have been updated to support the new signature.

Additionally, this change includes:
- A fix for an incorrect ffmpeg stream specifier that caused errors with multiple audio streams.
- Improved unit test coverage for error handling paths, such as partial ffmpeg failures.