### PR TITLE
feat: Update GitHub token for CI PR creation

### DIFF
--- a/.github/workflows/ci-release.yml
+++ b/.github/workflows/ci-release.yml
@@ -152,7 +152,7 @@ jobs:
         id: prepare_branch
         if: steps.update_version.outputs.version_updated == 'true'
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.PAT_FOR_CREATING_PR }}
         run: |
           BRANCH_NAME="feature/auto-version-update"
           echo "branch_name=$BRANCH_NAME" >> $GITHUB_OUTPUT


### PR DESCRIPTION
Replaced GITHUB_TOKEN with PAT_FOR_CREATING_PR in ci-release.yml
to use a dedicated Personal Access Token for creating pull requests
in the CI workflow.
