### PR TITLE
refactor: Stream ffmpeg stderr to fix MemoryError

### DIFF
--- a/tests/test_quality_check.py
+++ b/tests/test_quality_check.py
@@ -1,14 +1,16 @@
 """Unit and integration tests for the quality_check module."""
 
 from pathlib import Path
-from typing import Union
+from typing import AsyncGenerator, Union
 from unittest.mock import MagicMock
 
 import pytest
 from pytest_mock import MockerFixture
 
+from ts2mp4.ffmpeg import FFmpegProcessError
 from ts2mp4.quality_check import (
     AudioQualityMetrics,
+    check_audio_quality,
     get_audio_quality_metrics,
     parse_audio_quality_metrics,
 )
@@ -22,6 +24,7 @@ from ts2mp4.video_file import (
 
 
 @pytest.mark.unit
+@pytest.mark.asyncio
 @pytest.mark.parametrize(
     "ffmpeg_output, expected_apsnr, expected_asdr",
     [
@@ -30,51 +33,15 @@ from ts2mp4.video_file import (
             float("inf"),
             float("inf"),
         ),
-        (
-            "[Parsed_apsnr_0 @ 0x7f9990004800] PSNR ch0: 30.00 dB",
-            30.00,
-            None,
-        ),
-        (
-            "[Parsed_asdr_1 @ 0x7f9990004ac0] SDR ch0: 25.00 dB",
-            None,
-            25.00,
-        ),
-        (
-            "No metrics here",
-            None,
-            None,
-        ),
-        (
-            "[Parsed_apsnr_0 @ 0x7f9990004800] PSNR ch0: invalid dB",
-            None,
-            None,
-        ),
-        (
-            "[Parsed_asdr_1 @ 0x7f9990004ac0] SDR ch0: invalid dB",
-            None,
-            None,
-        ),
-        (
-            "[Parsed_apsnr_0 @ 0x7f9990004800] PSNR ch0: -10.50 dB",
-            -10.50,
-            None,
-        ),
-        (
-            "[Parsed_asdr_1 @ 0x7f9990004ac0] SDR ch0: -5.25 dB",
-            None,
-            -5.25,
-        ),
-        (
-            "[Parsed_apsnr_0 @ 0x7f9990004800] PSNR ch1: 42.0 dB",
-            42.0,
-            None,
-        ),
-        (
-            "[Parsed_asdr_1 @ 0x7f9990004ac0] SDR ch1: -nan dB",
-            None,
-            float("nan"),
-        ),
+        ("[Parsed_apsnr_0 @ 0x7f9990004800] PSNR ch0: 30.00 dB", 30.00, None),
+        ("[Parsed_asdr_1 @ 0x7f9990004ac0] SDR ch0: 25.00 dB", None, 25.00),
+        ("No metrics here", None, None),
+        ("[Parsed_apsnr_0 @ 0x7f9990004800] PSNR ch0: invalid dB", None, None),
+        ("[Parsed_asdr_1 @ 0x7f9990004ac0] SDR ch0: invalid dB", None, None),
+        ("[Parsed_apsnr_0 @ 0x7f9990004800] PSNR ch0: -10.50 dB", -10.50, None),
+        ("[Parsed_asdr_1 @ 0x7f9990004ac0] SDR ch0: -5.25 dB", None, -5.25),
+        ("[Parsed_apsnr_0 @ 0x7f9990004800] PSNR ch1: 42.0 dB", 42.0, None),
+        ("[Parsed_asdr_1 @ 0x7f9990004ac0] SDR ch1: -nan dB", None, float("nan")),
         (
             "[Parsed_apsnr_0 @ 0x123] PSNR ch0: 10.0 dB\n[Parsed_apsnr_0 @ 0x123] PSNR ch1: 20.0 dB",
             10.0,
@@ -82,27 +49,35 @@ from ts2mp4.video_file import (
         ),
     ],
 )
-def test_parse_audio_quality_metrics(
+async def test_parse_audio_quality_metrics(
     ffmpeg_output: str,
     expected_apsnr: Union[float, None],
     expected_asdr: Union[float, None],
 ) -> None:
     """Test parsing of audio quality metrics from FFmpeg output."""
-    metrics = parse_audio_quality_metrics(ffmpeg_output)
 
+    async def input_generator() -> AsyncGenerator[str, None]:
+        for line in ffmpeg_output.splitlines():
+            yield line
+
+    metrics = await parse_audio_quality_metrics(input_generator())
     assert metrics.apsnr == pytest.approx(expected_apsnr, nan_ok=True)
     assert metrics.asdr == pytest.approx(expected_asdr, nan_ok=True)
 
 
 @pytest.mark.unit
-def test_get_audio_quality_metrics_unit(mocker: MockerFixture) -> None:
+@pytest.mark.asyncio
+async def test_get_audio_quality_metrics_unit(mocker: MockerFixture) -> None:
     """Test the audio quality metrics calculation unit."""
-    mock_execute_ffmpeg = mocker.patch("ts2mp4.quality_check.execute_ffmpeg")
-    mock_execute_ffmpeg.return_value.returncode = 0
-    mock_execute_ffmpeg.return_value.stderr = (
-        "[Parsed_apsnr_0 @ 0x123] PSNR ch0: 30.00 dB\n"
-        "[Parsed_asdr_1 @ 0x456] SDR ch0: 25.00 dB"
-    )
+    mock_stream = mocker.patch("ts2mp4.quality_check.execute_ffmpeg_stderr_streamed")
+
+    async def mock_generator(
+        *args: object, **kwargs: object
+    ) -> AsyncGenerator[str, None]:
+        yield "[Parsed_apsnr_0 @ 0x123] PSNR ch0: 30.00 dB"
+        yield "[Parsed_asdr_1 @ 0x456] SDR ch0: 25.00 dB"
+
+    mock_stream.side_effect = mock_generator
 
     mock_converted_file = MagicMock(spec=ConvertedVideoFile)
     mock_stream1 = MagicMock(index=0, codec_type="audio")
@@ -128,31 +103,32 @@ def test_get_audio_quality_metrics_unit(mocker: MockerFixture) -> None:
     ]
     mock_converted_file.path = "converted.mp4"
 
-    metrics = get_audio_quality_metrics(mock_converted_file)
+    metrics = await get_audio_quality_metrics(mock_converted_file)
 
     assert len(metrics) == 2
     assert 0 in metrics
     assert 2 in metrics
     assert metrics[0] == AudioQualityMetrics(apsnr=30.00, asdr=25.00)
     assert metrics[2] == AudioQualityMetrics(apsnr=30.00, asdr=25.00)
-    assert mock_execute_ffmpeg.call_count == 2
+    assert mock_stream.call_count == 2
 
 
 @pytest.mark.unit
-def test_get_audio_quality_metrics_partial_failure(mocker: MockerFixture) -> None:
+@pytest.mark.asyncio
+async def test_get_audio_quality_metrics_partial_failure(
+    mocker: MockerFixture,
+) -> None:
     """Test quality metrics calculation with a partial FFmpeg failure."""
-    mock_execute_ffmpeg = mocker.patch("ts2mp4.quality_check.execute_ffmpeg")
+    mock_stream = mocker.patch("ts2mp4.quality_check.execute_ffmpeg_stderr_streamed")
 
-    # Simulate failure for the first call, success for the second
-    mock_result_fail = MagicMock(returncode=1, stderr="Error")
-    mock_result_success = MagicMock(
-        returncode=0,
-        stderr=(
-            "[Parsed_apsnr_0 @ 0x123] PSNR ch0: 30.00 dB\n"
-            "[Parsed_asdr_1 @ 0x456] SDR ch0: 25.00 dB"
-        ),
-    )
-    mock_execute_ffmpeg.side_effect = [mock_result_fail, mock_result_success]
+    async def mock_generator() -> AsyncGenerator[str, None]:
+        yield "[Parsed_apsnr_0 @ 0x123] PSNR ch0: 30.00 dB"
+        yield "[Parsed_asdr_1 @ 0x456] SDR ch0: 25.00 dB"
+
+    mock_stream.side_effect = [
+        FFmpegProcessError("Error"),
+        mock_generator(),
+    ]
 
     mock_converted_file = MagicMock(spec=ConvertedVideoFile)
     mock_stream1 = MagicMock(index=0, codec_type="audio")
@@ -175,20 +151,28 @@ def test_get_audio_quality_metrics_partial_failure(mocker: MockerFixture) -> Non
     ]
     mock_converted_file.path = "converted.mp4"
 
-    metrics = get_audio_quality_metrics(mock_converted_file)
+    metrics = await get_audio_quality_metrics(mock_converted_file)
 
     assert len(metrics) == 1
     assert 2 in metrics
     assert metrics[2] == AudioQualityMetrics(apsnr=30.00, asdr=25.00)
-    assert mock_execute_ffmpeg.call_count == 2
+    assert mock_stream.call_count == 2
 
 
 @pytest.mark.unit
-def test_get_audio_quality_metrics_no_metrics_parsed(mocker: MockerFixture) -> None:
+@pytest.mark.asyncio
+async def test_get_audio_quality_metrics_no_metrics_parsed(
+    mocker: MockerFixture,
+) -> None:
     """Test quality metrics calculation when no metrics are parsed from output."""
-    mock_execute_ffmpeg = mocker.patch("ts2mp4.quality_check.execute_ffmpeg")
-    mock_execute_ffmpeg.return_value.returncode = 0
-    mock_execute_ffmpeg.return_value.stderr = "No metrics here"
+    mock_stream = mocker.patch("ts2mp4.quality_check.execute_ffmpeg_stderr_streamed")
+
+    async def mock_generator(
+        *args: object, **kwargs: object
+    ) -> AsyncGenerator[str, None]:
+        yield "No metrics here"
+
+    mock_stream.side_effect = mock_generator
 
     mock_converted_file = MagicMock(spec=ConvertedVideoFile)
     mock_stream1 = MagicMock(index=0, codec_type="audio")
@@ -200,13 +184,25 @@ def test_get_audio_quality_metrics_no_metrics_parsed(mocker: MockerFixture) -> N
     mock_converted_file.stream_with_sources = [(mock_stream1, mock_source1)]
     mock_converted_file.path = "converted.mp4"
 
-    metrics = get_audio_quality_metrics(mock_converted_file)
+    metrics = await get_audio_quality_metrics(mock_converted_file)
 
     assert len(metrics) == 0
 
 
+@pytest.mark.unit
+def test_check_audio_quality(mocker: MockerFixture) -> None:
+    """Test the synchronous wrapper for get_audio_quality_metrics."""
+    mock_async_func = mocker.patch("ts2mp4.quality_check.get_audio_quality_metrics")
+    mock_converted_file = MagicMock(spec=ConvertedVideoFile)
+
+    check_audio_quality(mock_converted_file)
+
+    mock_async_func.assert_called_once_with(mock_converted_file)
+
+
 @pytest.mark.integration
-def test_get_audio_quality_metrics_integration(ts_file: Path) -> None:
+@pytest.mark.asyncio
+async def test_get_audio_quality_metrics_integration(ts_file: Path) -> None:
     """Test get_audio_quality_metrics with a real video file."""
     video_file = VideoFile(path=ts_file)
     stream_sources = []
@@ -227,7 +223,7 @@ def test_get_audio_quality_metrics_integration(ts_file: Path) -> None:
         path=ts_file, stream_sources=StreamSources(stream_sources)
     )
 
-    metrics_dict = get_audio_quality_metrics(converted_file)
+    metrics_dict = await get_audio_quality_metrics(converted_file)
 
     assert len(metrics_dict) == len(video_file.valid_audio_streams)
     for stream_index, metrics in metrics_dict.items():

--- a/ts2mp4/audio_reencoder.py
+++ b/ts2mp4/audio_reencoder.py
@@ -9,7 +9,7 @@ from typing_extensions import Self
 from .ffmpeg import execute_ffmpeg, is_libfdk_aac_available
 from .initial_converter import InitiallyConvertedVideoFile
 from .media_info import AudioStream
-from .quality_check import get_audio_quality_metrics
+from .quality_check import check_audio_quality
 from .stream_integrity import compare_stream_hashes, verify_copied_streams
 from .video_file import (
     ConversionType,
@@ -305,7 +305,7 @@ def re_encode_mismatched_audio_streams(
     verify_copied_streams(re_encoded_video_file)
 
     # Get quality metrics for re-encoded streams
-    quality_metrics = get_audio_quality_metrics(re_encoded_video_file)
+    quality_metrics = check_audio_quality(re_encoded_video_file)
     for stream_index, metrics in quality_metrics.items():
         log_parts = []
         if metrics.apsnr is not None:


### PR DESCRIPTION
Refactored the audio quality checking to fix a MemoryError.

The `get_audio_quality_metrics` function previously read the entire stderr output from ffmpeg into memory. This has been refactored to process the stderr stream line-by-line to keep memory usage low.

The key changes are:
- A new `execute_ffmpeg_stderr_streamed` async generator in `ffmpeg.py` streams stderr line-by-line.
- `quality_check.py` has been updated to use this stream.
- `parse_audio_quality_metrics` is now an `async` function that accepts an `AsyncIterable`, preserving the separation of parsing logic while correctly handling the stream without loading it all into memory.
- A synchronous wrapper, `check_audio_quality`, is kept for the public API to contain the async changes.
- Tests have been updated to reflect the new async nature of the parsing function.