### PR TITLE
feat: Refactor StreamSources to use pydantic.RootModel

### DIFF
--- a/tests/test_audio_reencoder.py
+++ b/tests/test_audio_reencoder.py
@@ -83,7 +83,7 @@ def mock_initially_converted_video_file_factory(
         )
 
         stream_sources = StreamSources(
-            tuple(
+            root=tuple(
                 StreamSource(
                     source_video_file=original_file,
                     source_stream_index=i,
@@ -294,19 +294,17 @@ def test_re_encode_mismatched_audio_streams_integration(
     encoded_video_file = InitiallyConvertedVideoFile(
         path=encoded_file_path,
         stream_sources=StreamSourcesForInitialConversion(
-            StreamSources(
-                (
-                    StreamSource(
-                        source_video_file=original_video_file,
-                        source_stream_index=original_streams[0].index,
-                        conversion_type=ConversionType.CONVERTED,
-                    ),
-                    StreamSource(
-                        source_video_file=original_video_file,
-                        source_stream_index=original_streams[1].index,
-                        conversion_type=ConversionType.COPIED,
-                    ),
-                )
+            root=(
+                StreamSource(
+                    source_video_file=original_video_file,
+                    source_stream_index=original_streams[0].index,
+                    conversion_type=ConversionType.CONVERTED,
+                ),
+                StreamSource(
+                    source_video_file=original_video_file,
+                    source_stream_index=original_streams[1].index,
+                    conversion_type=ConversionType.COPIED,
+                ),
             )
         ),
     )
@@ -329,19 +327,17 @@ def test_re_encode_mismatched_audio_streams_no_re_encoding_needed(
     original_streams = original_video_file.media_info.streams
 
     encoded_stream_sources = StreamSourcesForInitialConversion(
-        StreamSources(
-            tuple(
-                StreamSource(
-                    source_video_file=original_video_file,
-                    source_stream_index=s.index,
-                    conversion_type=(
-                        ConversionType.CONVERTED
-                        if s.codec_type == "video"
-                        else ConversionType.COPIED
-                    ),
-                )
-                for s in original_streams
+        root=tuple(
+            StreamSource(
+                source_video_file=original_video_file,
+                source_stream_index=s.index,
+                conversion_type=(
+                    ConversionType.CONVERTED
+                    if s.codec_type == "video"
+                    else ConversionType.COPIED
+                ),
             )
+            for s in original_streams
         )
     )
     encoded_video_file = InitiallyConvertedVideoFile(
@@ -437,23 +433,21 @@ def test_stream_sources_for_audio_re_encoding_validation_success(
     mock_original_file.path = Path("original.ts")
     mock_encoded_file.path = Path("encoded.mp4")
 
-    valid_sources = StreamSources(
-        [
-            mocker.MagicMock(
-                spec=StreamSource,
-                source_video_file=mock_encoded_file,
-                conversion_type=ConversionType.COPIED,
-                source_stream=mocker.MagicMock(spec=VideoStream, codec_type="video"),
-            ),
-            mocker.MagicMock(
-                spec=StreamSource,
-                source_video_file=mock_original_file,
-                conversion_type=ConversionType.CONVERTED,
-                source_stream=mocker.MagicMock(spec=AudioStream, codec_type="audio"),
-            ),
-        ]
-    )
-    StreamSourcesForAudioReEncoding(valid_sources)
+    valid_sources = [
+        mocker.MagicMock(
+            spec=StreamSource,
+            source_video_file=mock_encoded_file,
+            conversion_type=ConversionType.COPIED,
+            source_stream=mocker.MagicMock(spec=VideoStream, codec_type="video"),
+        ),
+        mocker.MagicMock(
+            spec=StreamSource,
+            source_video_file=mock_original_file,
+            conversion_type=ConversionType.CONVERTED,
+            source_stream=mocker.MagicMock(spec=AudioStream, codec_type="audio"),
+        ),
+    ]
+    StreamSourcesForAudioReEncoding(root=tuple(valid_sources))
 
 
 @pytest.mark.unit
@@ -559,4 +553,4 @@ def test_stream_sources_for_audio_re_encoding_validation_failures(
         )
 
     with pytest.raises(ValueError, match=error_message):
-        StreamSourcesForAudioReEncoding(StreamSources(sources))
+        StreamSourcesForAudioReEncoding(root=tuple(sources))

--- a/tests/test_initial_converter.py
+++ b/tests/test_initial_converter.py
@@ -85,7 +85,7 @@ def valid_stream_sources(
         source_stream_index=1,
         conversion_type=ConversionType.COPIED,
     )
-    return StreamSources((video_stream, audio_stream))
+    return StreamSources(root=(video_stream, audio_stream))
 
 
 @pytest.mark.unit
@@ -94,7 +94,7 @@ def test_stream_sources_for_initial_conversion_success(
 ) -> None:
     """Test that StreamSourcesForInitialConversion can be instantiated with valid data."""
     # This should not raise an error
-    instance = StreamSourcesForInitialConversion(valid_stream_sources)
+    instance = StreamSourcesForInitialConversion(root=valid_stream_sources.root)
     assert instance is not None
 
 
@@ -169,7 +169,7 @@ def test_stream_sources_for_initial_conversion_failures(
         sources.append(sources[0])
 
     with pytest.raises(ValueError, match=error_message):
-        StreamSourcesForInitialConversion(StreamSources(sources))
+        StreamSourcesForInitialConversion(root=tuple(sources))
 
 
 @pytest.fixture
@@ -177,26 +177,24 @@ def stream_sources_for_initial_conversion(
     mock_video_file: VideoFile,
 ) -> StreamSourcesForInitialConversion:
     """Create a StreamSourcesForInitialConversion instance for testing."""
-    sources = StreamSources(
-        (
-            StreamSource(
-                source_video_file=mock_video_file,
-                source_stream_index=0,
-                conversion_type=ConversionType.CONVERTED,
-            ),
-            StreamSource(
-                source_video_file=mock_video_file,
-                source_stream_index=1,
-                conversion_type=ConversionType.COPIED,
-            ),
-            StreamSource(
-                source_video_file=mock_video_file,
-                source_stream_index=2,
-                conversion_type=ConversionType.COPIED,
-            ),
-        )
+    sources = (
+        StreamSource(
+            source_video_file=mock_video_file,
+            source_stream_index=0,
+            conversion_type=ConversionType.CONVERTED,
+        ),
+        StreamSource(
+            source_video_file=mock_video_file,
+            source_stream_index=1,
+            conversion_type=ConversionType.COPIED,
+        ),
+        StreamSource(
+            source_video_file=mock_video_file,
+            source_stream_index=2,
+            conversion_type=ConversionType.COPIED,
+        ),
     )
-    return StreamSourcesForInitialConversion(sources)
+    return StreamSourcesForInitialConversion(root=sources)
 
 
 @pytest.mark.unit

--- a/tests/test_quality_check.py
+++ b/tests/test_quality_check.py
@@ -220,7 +220,7 @@ async def test_get_audio_quality_metrics_integration(ts_file: Path) -> None:
         )
 
     converted_file = ConvertedVideoFile(
-        path=ts_file, stream_sources=StreamSources(stream_sources)
+        path=ts_file, stream_sources=StreamSources(root=tuple(stream_sources))
     )
 
     metrics_dict = await get_audio_quality_metrics(converted_file)

--- a/tests/test_stream_integrity.py
+++ b/tests/test_stream_integrity.py
@@ -119,7 +119,7 @@ def mock_converted_video_file(
     mock_converted_file.path = mock_output_video_file.path
     mock_converted_file.media_info = mock_output_video_file.media_info
     mock_converted_file.stream_sources = StreamSources(
-        [
+        root=(
             StreamSource(
                 source_video_file=mock_input_video_file,
                 source_stream_index=0,
@@ -130,7 +130,7 @@ def mock_converted_video_file(
                 source_stream_index=1,
                 conversion_type=ConversionType.COPIED,
             ),
-        ]
+        )
     )
 
     # MagicMock doesn't automatically handle properties that are generators
@@ -181,7 +181,7 @@ def test_verify_copied_streams_no_copied_streams(
         source_stream_index=1,
         conversion_type=ConversionType.CONVERTED,
     )
-    mock_converted_video_file.stream_sources = StreamSources(stream_sources)
+    mock_converted_video_file.stream_sources = StreamSources(root=tuple(stream_sources))
 
     type(mock_converted_video_file).stream_with_sources = mocker.PropertyMock(
         return_value=zip(

--- a/tests/test_video_file.py
+++ b/tests/test_video_file.py
@@ -90,7 +90,7 @@ def stream_sources(
     )
 
     return StreamSources(
-        (
+        root=(
             StreamSource(
                 source_video_file=video_file_1,
                 source_stream_index=0,
@@ -217,7 +217,7 @@ def test_converted_video_file_instantiation(
         return_value=MediaInfo(streams=(VideoStream(codec_type="video", index=0),)),
     )
 
-    stream_sources = StreamSources((stream_source,))
+    stream_sources = StreamSources(root=(stream_source,))
     converted_file = ConvertedVideoFile(
         path=dummy_video_file.path,
         stream_sources=stream_sources,
@@ -259,7 +259,7 @@ def test_stream_sources_source_video_files_property(
 @pytest.mark.unit
 def test_stream_sources_properties_with_empty_sources() -> None:
     """Test that StreamSources properties work correctly with no sources."""
-    empty_stream_sources = StreamSources(())
+    empty_stream_sources = StreamSources(root=())
     assert len(empty_stream_sources.video_stream_sources) == 0
     assert len(empty_stream_sources.audio_stream_sources) == 0
     assert len(empty_stream_sources.source_video_files) == 0
@@ -281,7 +281,7 @@ def test_converted_video_file_mismatched_stream_counts_raises_error(
         ),
     )
 
-    stream_sources = StreamSources((stream_source,))  # Only one stream source
+    stream_sources = StreamSources(root=(stream_source,))  # Only one stream source
     with pytest.raises(ValueError, match="Mismatch in stream counts"):
         ConvertedVideoFile(
             path=dummy_video_file.path,
@@ -300,7 +300,7 @@ def test_converted_video_file_stream_with_sources_property(
         return_value=MediaInfo(streams=(mock_stream,)),
     )
 
-    stream_sources = StreamSources((stream_source,))
+    stream_sources = StreamSources(root=(stream_source,))
     converted_file = ConvertedVideoFile(
         path=dummy_video_file.path,
         stream_sources=stream_sources,

--- a/ts2mp4/initial_converter.py
+++ b/ts2mp4/initial_converter.py
@@ -2,6 +2,7 @@
 
 from pathlib import Path
 
+from pydantic import model_validator
 from typing_extensions import Self
 
 from .ffmpeg import execute_ffmpeg
@@ -17,52 +18,51 @@ from .video_file import (
 class StreamSourcesForInitialConversion(StreamSources):
     """Represents the stream sources for the initial conversion."""
 
-    def __new__(cls, stream_sources: StreamSources) -> Self:
-        """Initialize the StreamSourcesForInitialConversion."""
+    @model_validator(mode="after")
+    def validate_stream_sources(self) -> Self:
+        """Validate the stream sources."""
         # Stream sources must have at least one video stream
-        if not stream_sources.video_stream_sources:
+        if not self.video_stream_sources:
             raise ValueError("At least one video stream is required.")
 
         # Stream sources must have at least one audio stream
-        if not stream_sources.audio_stream_sources:
+        if not self.audio_stream_sources:
             raise ValueError("At least one audio stream is required.")
 
         # All video streams must be converted
         if not all(
             s.conversion_type == ConversionType.CONVERTED
-            for s in stream_sources.video_stream_sources
+            for s in self.video_stream_sources
         ):
             raise ValueError("All video streams must be converted.")
 
         # All audio streams must be copied
         if not all(
             s.conversion_type == ConversionType.COPIED
-            for s in stream_sources.audio_stream_sources
+            for s in self.audio_stream_sources
         ):
             raise ValueError("All audio streams must be copied.")
 
         # Stream source must not have any other types
-        if not all(
-            s.source_stream.codec_type in ["video", "audio"] for s in stream_sources
-        ):
+        if not all(s.source_stream.codec_type in ["video", "audio"] for s in self.root):
             raise ValueError("Stream sources must only contain video or audio streams.")
 
         # All stream sources must originate from the same VideoFile
-        if len(stream_sources.source_video_files) != 1:
+        if len(self.source_video_files) != 1:
             raise ValueError(
                 "All stream sources must originate from the same VideoFile."
             )
 
         # Source streams must be unique
-        if len(set(s.source_stream for s in stream_sources)) < len(stream_sources):
+        if len(set(s.source_stream for s in self.root)) < len(self.root):
             raise ValueError("Source streams must be unique.")
 
-        return super().__new__(cls, stream_sources)
+        return self
 
     @property
     def source_video_file(self) -> VideoFile:
         """Return the source video file for the stream sources."""
-        return self[0].source_video_file
+        return self.root[0].source_video_file
 
 
 class InitiallyConvertedVideoFile(ConvertedVideoFile):
@@ -74,20 +74,22 @@ class InitiallyConvertedVideoFile(ConvertedVideoFile):
 def _build_stream_sources(input_file: VideoFile) -> StreamSourcesForInitialConversion:
     """Build the stream sources for the initial conversion."""
     stream_sources = StreamSources(
-        StreamSource(
-            source_video_file=input_file,
-            source_stream_index=stream.index,
-            conversion_type=(
-                ConversionType.CONVERTED
-                if stream.codec_type == "video"
-                else ConversionType.COPIED
-            ),
+        root=tuple(
+            StreamSource(
+                source_video_file=input_file,
+                source_stream_index=stream.index,
+                conversion_type=(
+                    ConversionType.CONVERTED
+                    if stream.codec_type == "video"
+                    else ConversionType.COPIED
+                ),
+            )
+            for stream in sorted(input_file.valid_streams, key=lambda s: s.index)
+            if stream.codec_type in ["video", "audio"]
         )
-        for stream in sorted(input_file.valid_streams, key=lambda s: s.index)
-        if stream.codec_type in ["video", "audio"]
     )
 
-    return StreamSourcesForInitialConversion(stream_sources)
+    return StreamSourcesForInitialConversion(root=stream_sources.root)
 
 
 def _build_ffmpeg_args_from_stream_sources(


### PR DESCRIPTION
This refactors the `StreamSources` class and its subclasses to use `pydantic.RootModel` instead of inheriting from `tuple`. This change improves type safety and consistency with other pydantic models in the codebase.

The following changes were made:
- `StreamSources` now inherits from `RootModel[tuple[StreamSource, ...]]`.
- `__iter__`, `__getitem__`, and `__len__` methods were added to `StreamSources` to maintain tuple-like behavior.
- `StreamSources` is now hashable due to `frozen=True` in its model config.
- `StreamSourcesForInitialConversion` and `StreamSourcesForAudioReEncoding` now use `model_validator` for validation instead of `__new__`.
- All instantiations of `StreamSources` and its subclasses have been updated to align with the new `RootModel` implementation.
- All related `mypy` and `ruff` errors have been resolved.