### PR TITLE
refactor(streamsource): use path and Stream object

### DIFF
--- a/tests/test_initial_converter.py
+++ b/tests/test_initial_converter.py
@@ -76,13 +76,13 @@ def valid_stream_sources(
     """Fixture to create a valid StreamSources object for validation tests."""
     video_file = mock_video_file_factory()
     video_stream = StreamSource(
-        source_video_file=video_file,
-        source_stream_index=0,
+        source_video_path=video_file.path,
+        source_stream=video_file.media_info.streams[0],
         conversion_type=ConversionType.CONVERTED,
     )
     audio_stream = StreamSource(
-        source_video_file=video_file,
-        source_stream_index=1,
+        source_video_path=video_file.path,
+        source_stream=video_file.media_info.streams[1],
         conversion_type=ConversionType.COPIED,
     )
     return StreamSources(root=(video_stream, audio_stream))
@@ -125,7 +125,7 @@ def test_stream_sources_for_initial_conversion_failures(
     mocker: MockerFixture,
 ) -> None:
     """Test the validation rules in StreamSourcesForInitialConversion.__new__."""
-    video_file = valid_stream_sources[0].source_video_file
+    video_file = VideoFile(path=valid_stream_sources[0].source_video_path)
     sources = list(valid_stream_sources)
 
     if modifier == "no_video":
@@ -134,22 +134,22 @@ def test_stream_sources_for_initial_conversion_failures(
         sources = [s for s in sources if s.source_stream.codec_type != "audio"]
     elif modifier == "video_not_converted":
         sources[0] = StreamSource(
-            source_video_file=video_file,
-            source_stream_index=0,
+            source_video_path=video_file.path,
+            source_stream=video_file.media_info.streams[0],
             conversion_type=ConversionType.COPIED,
         )
     elif modifier == "audio_not_copied":
         sources[1] = StreamSource(
-            source_video_file=video_file,
-            source_stream_index=1,
+            source_video_path=video_file.path,
+            source_stream=video_file.media_info.streams[1],
             conversion_type=ConversionType.CONVERTED,
         )
     elif modifier == "multiple_sources":
         other_video_file = mock_video_file_factory(file_name="other.ts")
         sources.append(
             StreamSource(
-                source_video_file=other_video_file,
-                source_stream_index=0,
+                source_video_path=other_video_file.path,
+                source_stream=other_video_file.media_info.streams[0],
                 conversion_type=ConversionType.CONVERTED,
             )
         )
@@ -160,8 +160,8 @@ def test_stream_sources_for_initial_conversion_failures(
         mocker.patch("ts2mp4.video_file.get_media_info", return_value=new_media_info)
         sources.append(
             StreamSource(
-                source_video_file=video_file,
-                source_stream_index=2,
+                source_video_path=video_file.path,
+                source_stream=subtitle_stream,
                 conversion_type=ConversionType.COPIED,
             )
         )
@@ -174,23 +174,24 @@ def test_stream_sources_for_initial_conversion_failures(
 
 @pytest.fixture
 def stream_sources_for_initial_conversion(
-    mock_video_file: VideoFile,
+    mock_video_file_factory: Callable[..., VideoFile],
 ) -> StreamSourcesForInitialConversion:
     """Create a StreamSourcesForInitialConversion instance for testing."""
+    mock_video_file = mock_video_file_factory(video_streams=1, audio_streams=2)
     sources = (
         StreamSource(
-            source_video_file=mock_video_file,
-            source_stream_index=0,
+            source_video_path=mock_video_file.path,
+            source_stream=mock_video_file.media_info.streams[0],
             conversion_type=ConversionType.CONVERTED,
         ),
         StreamSource(
-            source_video_file=mock_video_file,
-            source_stream_index=1,
+            source_video_path=mock_video_file.path,
+            source_stream=mock_video_file.media_info.streams[1],
             conversion_type=ConversionType.COPIED,
         ),
         StreamSource(
-            source_video_file=mock_video_file,
-            source_stream_index=2,
+            source_video_path=mock_video_file.path,
+            source_stream=mock_video_file.media_info.streams[2],
             conversion_type=ConversionType.COPIED,
         ),
     )
@@ -250,9 +251,10 @@ def test_build_ffmpeg_args_from_stream_sources(
 
 @pytest.mark.unit
 def test_perform_initial_conversion_success(
-    mock_video_file: VideoFile, mocker: MockerFixture
+    mock_video_file_factory: Callable[..., VideoFile], mocker: MockerFixture
 ) -> None:
     """Test that perform_initial_conversion executes FFmpeg successfully."""
+    mock_video_file = mock_video_file_factory()
     output_file = Path("output.mp4")
     crf = 23
     preset = "medium"
@@ -285,9 +287,10 @@ def test_perform_initial_conversion_success(
 
 @pytest.mark.unit
 def test_perform_initial_conversion_ffmpeg_failure(
-    mock_video_file: VideoFile, mocker: MockerFixture
+    mock_video_file_factory: Callable[..., VideoFile], mocker: MockerFixture
 ) -> None:
     """Test that perform_initial_conversion raises RuntimeError on FFmpeg failure."""
+    mock_video_file = mock_video_file_factory()
     output_file = Path("output.mp4")
     crf = 23
     preset = "medium"

--- a/tests/test_quality_check.py
+++ b/tests/test_quality_check.py
@@ -87,13 +87,13 @@ async def test_get_audio_quality_metrics_unit(mocker: MockerFixture) -> None:
     mock_source1 = MagicMock(
         conversion_type=ConversionType.CONVERTED,
         source_stream=MagicMock(index=0),
-        source_video_file=MagicMock(path="original.ts"),
+        source_video_path="original.ts",
     )
     mock_source2 = MagicMock(conversion_type=ConversionType.COPIED)
     mock_source3 = MagicMock(
         conversion_type=ConversionType.CONVERTED,
         source_stream=MagicMock(index=1),
-        source_video_file=MagicMock(path="original.ts"),
+        source_video_path="original.ts",
     )
 
     mock_converted_file.stream_with_sources = [
@@ -137,12 +137,12 @@ async def test_get_audio_quality_metrics_partial_failure(
     mock_source1 = MagicMock(
         conversion_type=ConversionType.CONVERTED,
         source_stream=MagicMock(index=0),
-        source_video_file=MagicMock(path="original.ts"),
+        source_video_path="original.ts",
     )
     mock_source2 = MagicMock(
         conversion_type=ConversionType.CONVERTED,
         source_stream=MagicMock(index=1),
-        source_video_file=MagicMock(path="original.ts"),
+        source_video_path="original.ts",
     )
 
     mock_converted_file.stream_with_sources = [
@@ -179,7 +179,7 @@ async def test_get_audio_quality_metrics_no_metrics_parsed(
     mock_source1 = MagicMock(
         conversion_type=ConversionType.CONVERTED,
         source_stream=MagicMock(index=0),
-        source_video_file=MagicMock(path="original.ts"),
+        source_video_path="original.ts",
     )
     mock_converted_file.stream_with_sources = [(mock_stream1, mock_source1)]
     mock_converted_file.path = "converted.mp4"
@@ -209,8 +209,8 @@ async def test_get_audio_quality_metrics_integration(ts_file: Path) -> None:
     for stream in video_file.media_info.streams:
         stream_sources.append(
             StreamSource(
-                source_video_file=video_file,
-                source_stream_index=stream.index,
+                source_video_path=video_file.path,
+                source_stream=stream,
                 conversion_type=(
                     ConversionType.CONVERTED
                     if stream.codec_type == "audio"

--- a/tests/test_stream_integrity.py
+++ b/tests/test_stream_integrity.py
@@ -19,10 +19,12 @@ from ts2mp4.video_file import (
 
 
 @pytest.fixture
-def mock_input_video_file(mocker: MockerFixture) -> MagicMock:
+def mock_input_video_file(mocker: MockerFixture, tmp_path: Path) -> MagicMock:
     """Return a mocked input VideoFile instance."""
     mock_input = cast(MagicMock, mocker.MagicMock(spec=VideoFile))
-    mock_input.path = Path("dummy_input.ts")
+    dummy_file = tmp_path / "dummy_input.ts"
+    dummy_file.touch()
+    mock_input.path = dummy_file
     # Set default media_info for input, can be overridden in tests if needed
     mock_input.media_info = MediaInfo(
         streams=(
@@ -34,10 +36,12 @@ def mock_input_video_file(mocker: MockerFixture) -> MagicMock:
 
 
 @pytest.fixture
-def mock_output_video_file(mocker: MockerFixture) -> MagicMock:
+def mock_output_video_file(mocker: MockerFixture, tmp_path: Path) -> MagicMock:
     """Return a mocked output VideoFile instance."""
     mock_output = cast(MagicMock, mocker.MagicMock(spec=VideoFile))
-    mock_output.path = Path("dummy_output.mp4.part")
+    dummy_file = tmp_path / "dummy_output.mp4.part"
+    dummy_file.touch()
+    mock_output.path = dummy_file
     # Set default media_info for output, can be overridden in tests if needed
     mock_output.media_info = MediaInfo(
         streams=(
@@ -121,13 +125,13 @@ def mock_converted_video_file(
     mock_converted_file.stream_sources = StreamSources(
         root=(
             StreamSource(
-                source_video_file=mock_input_video_file,
-                source_stream_index=0,
+                source_video_path=mock_input_video_file.path,
+                source_stream=mock_input_video_file.media_info.streams[0],
                 conversion_type=ConversionType.CONVERTED,
             ),
             StreamSource(
-                source_video_file=mock_input_video_file,
-                source_stream_index=1,
+                source_video_path=mock_input_video_file.path,
+                source_stream=mock_input_video_file.media_info.streams[1],
                 conversion_type=ConversionType.COPIED,
             ),
         )
@@ -177,8 +181,8 @@ def test_verify_copied_streams_no_copied_streams(
     )
     stream_sources = list(mock_converted_video_file.stream_sources)
     stream_sources[1] = StreamSource(
-        source_video_file=stream_sources[1].source_video_file,
-        source_stream_index=1,
+        source_video_path=stream_sources[1].source_video_path,
+        source_stream=stream_sources[1].source_stream,
         conversion_type=ConversionType.CONVERTED,
     )
     mock_converted_video_file.stream_sources = StreamSources(root=tuple(stream_sources))

--- a/ts2mp4/initial_converter.py
+++ b/ts2mp4/initial_converter.py
@@ -63,7 +63,7 @@ class StreamSourcesForInitialConversion(StreamSources):
     @property
     def source_video_file(self) -> VideoFile:
         """Return the source video file for the stream sources."""
-        return self.root[0].source_video_file
+        return next(iter(self.source_video_files))
 
 
 class InitiallyConvertedVideoFile(ConvertedVideoFile):
@@ -77,8 +77,8 @@ def _build_stream_sources(input_file: VideoFile) -> StreamSourcesForInitialConve
     stream_sources = StreamSources(
         root=tuple(
             StreamSource(
-                source_video_file=input_file,
-                source_stream_index=stream.index,
+                source_video_path=input_file.path,
+                source_stream=stream,
                 conversion_type=(
                     ConversionType.CONVERTED
                     if stream.codec_type == "video"
@@ -113,7 +113,7 @@ def _build_ffmpeg_args_from_stream_sources(
         + [
             arg
             for source in stream_sources
-            for arg in ("-map", f"0:{source.source_stream_index}")
+            for arg in ("-map", f"0:{source.source_stream.index}")
         ]
         + [
             "-f",

--- a/ts2mp4/quality_check.py
+++ b/ts2mp4/quality_check.py
@@ -82,7 +82,7 @@ async def get_audio_quality_metrics(
         ):
             continue
 
-        original_file = stream_source.source_video_file.path
+        original_file = stream_source.source_video_path
         re_encoded_file = converted_file.path
         original_stream_index = stream_source.source_stream.index
         re_encoded_stream_index = stream.index

--- a/ts2mp4/stream_integrity.py
+++ b/ts2mp4/stream_integrity.py
@@ -63,7 +63,7 @@ def verify_copied_streams(converted_file: ConvertedVideoFile) -> None:
             continue
 
         if not compare_stream_hashes(
-            input_video=stream_source.source_video_file,
+            input_video=VideoFile(path=stream_source.source_video_path),
             output_video=converted_file,
             input_stream=stream_source.source_stream,
             output_stream=output_stream,


### PR DESCRIPTION
Refactors the StreamSource class to hold a video file path and a Stream object, instead of a VideoFile object and a stream index.

This change simplifies the data model and removes the need to look up the stream from the video file every time it's accessed.

The refactoring has been applied to:
- ts2mp4/video_file.py
- ts2mp4/initial_converter.py
- ts2mp4/audio_reencoder.py
- ts2mp4/stream_integrity.py
- ts2mp4/quality_check.py

The test suite has been updated to reflect these changes, and all tests are now passing.