### PR TITLE
feat(refactor): separate responsibilities of audio_reencoder and ts2mp4

### DIFF
--- a/ts2mp4/audio_reencoder.py
+++ b/ts2mp4/audio_reencoder.py
@@ -10,8 +10,7 @@ from typing_extensions import Self
 from .ffmpeg import execute_ffmpeg, is_libfdk_aac_available
 from .initial_converter import InitiallyConvertedVideoFile
 from .media_info import AudioStream, VideoStream
-from .quality_check import check_audio_quality
-from .stream_integrity import compare_stream_hashes, verify_copied_streams
+from .stream_integrity import compare_stream_hashes
 from .video_file import (
     ConversionT,
     ConvertedVideoFile,
@@ -291,21 +290,5 @@ def re_encode_mismatched_audio_streams(
     re_encoded_video_file = AudioReEncodedVideoFile(
         path=output_file, stream_sources=stream_sources
     )
-
-    # Verify integrity of copied streams
-    verify_copied_streams(re_encoded_video_file)
-
-    # Get quality metrics for re-encoded streams
-    quality_metrics = check_audio_quality(re_encoded_video_file)
-    for stream_index, metrics in quality_metrics.items():
-        log_parts = []
-        if metrics.apsnr is not None:
-            log_parts.append(f"APSNR={metrics.apsnr:.2f}dB")
-        if metrics.asdr is not None:
-            log_parts.append(f"ASDR={metrics.asdr:.2f}dB")
-        if log_parts:
-            logger.info(
-                f"Audio quality for stream {stream_index}: {', '.join(log_parts)}"
-            )
 
     return re_encoded_video_file


### PR DESCRIPTION
Refactors the audio re-encoding and verification process to achieve a better separation of concerns between the `audio_reencoder` and `ts2mp4` modules.

- The `audio_reencoder` module is now solely responsible for executing the FFmpeg re-encoding process. Verification and quality check logic has been removed from it.
- The `ts2mp4` module now orchestrates the verification and quality checking steps after a re-encoding is performed.
- Tests have been updated to reflect the new workflow.