### PR TITLE
ci: trigger workflow on force-push from version update job

### DIFF
--- a/.github/workflows/ci-release.yml
+++ b/.github/workflows/ci-release.yml
@@ -103,6 +103,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v5.0.0
+        with:
+          token: ${{ secrets.PAT_FOR_CREATING_PR }}
 
       - name: Install poetry
         run: pipx install poetry


### PR DESCRIPTION
The `propose-version-update` job performs a force-push to a PR branch. By default, pushes from GitHub Actions using `secrets.GITHUB_TOKEN` do not trigger new workflow runs to prevent infinite loops.

This change modifies the `checkout` step in the `propose-version-update` job to use a Personal Access Token (PAT). This ensures that the `git push` command is authenticated with the PAT, allowing it to trigger the `pull_request` CI workflow correctly on force-pushes.