### PR TITLE
refactor: Remove arbitrary_types_allowed from ConvertedVideoFile

### DIFF
--- a/ts2mp4/video_file.py
+++ b/ts2mp4/video_file.py
@@ -139,7 +139,7 @@ class ConvertedVideoFile(VideoFile):
 
     stream_sources: StreamSources
 
-    model_config = ConfigDict(arbitrary_types_allowed=True, frozen=True)
+    model_config = ConfigDict(frozen=True)
 
     @model_validator(mode="after")
     def validate_stream_counts(self) -> "ConvertedVideoFile":


### PR DESCRIPTION
Removes `arbitrary_types_allowed=True` from the Pydantic model configuration.

This enhances type safety by ensuring that all types are explicitly handled and validated by Pydantic, preventing unexpected types from being allowed in the model.
