### PR TITLE
refactor: Rename ConversionT to ConversionType

### DIFF
--- a/tests/test_quality_check.py
+++ b/tests/test_quality_check.py
@@ -16,7 +16,7 @@ from ts2mp4.quality_check import (
     parse_audio_quality_metrics,
 )
 from ts2mp4.video_file import (
-    ConversionT,
+    ConversionType,
     ConvertedVideoFile,
     StreamSource,
     StreamSources,
@@ -206,7 +206,7 @@ def test_check_audio_quality(mocker: MockerFixture) -> None:
 async def test_get_audio_quality_metrics_integration(ts_file: Path) -> None:
     """Test get_audio_quality_metrics with a real video file."""
     video_file = VideoFile(path=ts_file)
-    stream_sources: list[StreamSource[Stream, ConversionT]] = []
+    stream_sources: list[StreamSource[Stream, ConversionType]] = []
     for stream in video_file.media_info.streams:
         stream_sources.append(
             StreamSource(

--- a/tests/test_video_file.py
+++ b/tests/test_video_file.py
@@ -10,7 +10,7 @@ from pytest_mock import MockerFixture
 
 from ts2mp4.media_info import AudioStream, MediaInfo, OtherStream, VideoStream
 from ts2mp4.video_file import (
-    ConversionT,
+    ConversionType,
     ConvertedVideoFile,
     StreamSource,
     StreamSources,
@@ -48,7 +48,7 @@ def dummy_video_file(tmp_path: Path) -> VideoFile:
 @pytest.fixture
 def stream_source(
     dummy_video_file: VideoFile,
-) -> StreamSource[VideoStream, ConversionT]:
+) -> StreamSource[VideoStream, ConversionType]:
     """Create a dummy StreamSource instance."""
     return StreamSource(
         source_video_path=dummy_video_file.path,
@@ -186,7 +186,7 @@ def test_videofile_valid_streams_property(
 def test_stream_source_instantiation(dummy_video_file: VideoFile) -> None:
     """Test that StreamSource can be instantiated with valid data."""
     stream = VideoStream(codec_type="video", index=0)
-    stream_source: StreamSource[VideoStream, ConversionT] = StreamSource(
+    stream_source: StreamSource[VideoStream, ConversionType] = StreamSource(
         source_video_path=dummy_video_file.path,
         source_stream=stream,
         conversion_type="copied",
@@ -199,7 +199,7 @@ def test_stream_source_instantiation(dummy_video_file: VideoFile) -> None:
 @pytest.mark.unit
 def test_converted_video_file_instantiation(
     dummy_video_file: VideoFile,
-    stream_source: StreamSource[VideoStream, ConversionT],
+    stream_source: StreamSource[VideoStream, ConversionType],
     mocker: MockerFixture,
 ) -> None:
     """Test that ConvertedVideoFile can be instantiated with valid data."""
@@ -260,7 +260,7 @@ def test_stream_sources_properties_with_empty_sources() -> None:
 @pytest.mark.unit
 def test_converted_video_file_mismatched_stream_counts_raises_error(
     dummy_video_file: VideoFile,
-    stream_source: StreamSource[VideoStream, ConversionT],
+    stream_source: StreamSource[VideoStream, ConversionType],
     mocker: MockerFixture,
 ) -> None:
     """Test that ConvertedVideoFile raises ValueError for mismatched stream counts."""
@@ -286,7 +286,7 @@ def test_converted_video_file_mismatched_stream_counts_raises_error(
 @pytest.mark.unit
 def test_converted_video_file_stream_with_sources_property(
     dummy_video_file: VideoFile,
-    stream_source: StreamSource[VideoStream, ConversionT],
+    stream_source: StreamSource[VideoStream, ConversionType],
     mocker: MockerFixture,
 ) -> None:
     """Test the stream_with_sources property of ConvertedVideoFile."""

--- a/ts2mp4/audio_reencoder.py
+++ b/ts2mp4/audio_reencoder.py
@@ -12,7 +12,7 @@ from .initial_converter import InitiallyConvertedVideoFile
 from .media_info import AudioStream, VideoStream
 from .stream_integrity import compare_stream_hashes
 from .video_file import (
-    ConversionT,
+    ConversionType,
     ConvertedVideoFile,
     StreamSource,
     StreamSources,
@@ -137,7 +137,7 @@ def _build_stream_sources_for_audio_re_encoding(
 
 
 def _build_audio_convert_args(
-    stream_source: StreamSource[AudioStream, ConversionT], output_stream_index: int
+    stream_source: StreamSource[AudioStream, ConversionType], output_stream_index: int
 ) -> list[str]:
     """Build FFmpeg arguments for converting an audio stream."""
     original_audio_stream = stream_source.source_stream

--- a/ts2mp4/video_file.py
+++ b/ts2mp4/video_file.py
@@ -58,8 +58,8 @@ class VideoFile(BaseModel):
         return self.valid_video_streams + self.valid_audio_streams
 
 
-ConversionT = Literal["converted", "copied"]
-ConversionTypeT = TypeVar("ConversionTypeT", bound=ConversionT, covariant=True)
+ConversionType = Literal["converted", "copied"]
+ConversionTypeT = TypeVar("ConversionTypeT", bound=ConversionType, covariant=True)
 
 
 class StreamSource(BaseModel, Generic[StreamT, ConversionTypeT]):
@@ -86,16 +86,16 @@ def is_audio_stream_source(
     return isinstance(source.source_stream, AudioStream)
 
 
-class StreamSources(RootModel[tuple[StreamSource[Stream, ConversionT], ...]]):
+class StreamSources(RootModel[tuple[StreamSource[Stream, ConversionType], ...]]):
     """A tuple of StreamSource objects."""
 
     model_config = ConfigDict(frozen=True)
 
-    def __iter__(self) -> Iterator[StreamSource[Stream, ConversionT]]:  # type: ignore[override]
+    def __iter__(self) -> Iterator[StreamSource[Stream, ConversionType]]:  # type: ignore[override]
         """Return an iterator over the StreamSource objects."""
         return iter(self.root)
 
-    def __getitem__(self, item: int) -> StreamSource[Stream, ConversionT]:
+    def __getitem__(self, item: int) -> StreamSource[Stream, ConversionType]:
         """Return the StreamSource object at the given index."""
         return self.root[item]
 
@@ -106,14 +106,14 @@ class StreamSources(RootModel[tuple[StreamSource[Stream, ConversionT], ...]]):
     @property
     def video_stream_sources(
         self,
-    ) -> frozenset[StreamSource[VideoStream, ConversionT]]:
+    ) -> frozenset[StreamSource[VideoStream, ConversionType]]:
         """Return a set of video stream sources."""
         return frozenset(filter(is_video_stream_source, self.root))
 
     @property
     def audio_stream_sources(
         self,
-    ) -> frozenset[StreamSource[AudioStream, ConversionT]]:
+    ) -> frozenset[StreamSource[AudioStream, ConversionType]]:
         """Return a set of audio stream sources."""
         return frozenset(filter(is_audio_stream_source, self.root))
 
@@ -155,6 +155,6 @@ class ConvertedVideoFile(VideoFile):
     @property
     def stream_with_sources(
         self,
-    ) -> Iterator[tuple[Stream, StreamSource[Stream, ConversionT]]]:
+    ) -> Iterator[tuple[Stream, StreamSource[Stream, ConversionType]]]:
         """Return a zip object of output streams and their sources."""
         return zip(self.media_info.streams, self.stream_sources)


### PR DESCRIPTION
Renames the type alias `ConversionT` to `ConversionType` for improved clarity and consistency.

This change is applied across the following files:
- ts2mp4/video_file.py
- ts2mp4/audio_reencoder.py
- tests/test_video_file.py
- tests/test_quality_check.py
