### PR TITLE
refactor: Modernize type hints to Python 3.12+ syntax

### DIFF
--- a/tests/test_quality_check.py
+++ b/tests/test_quality_check.py
@@ -1,7 +1,7 @@
 """Unit and integration tests for the quality_check module."""
 
 from pathlib import Path
-from typing import AsyncGenerator, Union
+from typing import AsyncGenerator
 from unittest.mock import MagicMock
 
 import pytest
@@ -52,8 +52,8 @@ from ts2mp4.video_file import (
 )
 async def test_parse_audio_quality_metrics(
     ffmpeg_output: str,
-    expected_apsnr: Union[float, None],
-    expected_asdr: Union[float, None],
+    expected_apsnr: float | None,
+    expected_asdr: float | None,
 ) -> None:
     """Test parsing of audio quality metrics from FFmpeg output."""
 

--- a/ts2mp4/audio_reencoder.py
+++ b/ts2mp4/audio_reencoder.py
@@ -1,11 +1,10 @@
 """Re-encodes audio streams that have integrity issues."""
 
 from pathlib import Path
-from typing import Literal, Optional, Union
+from typing import Literal, Optional, Self
 
 from logzero import logger
 from pydantic import model_validator
-from typing_extensions import Self
 
 from .ffmpeg import execute_ffmpeg, is_libfdk_aac_available
 from .initial_converter import InitiallyConvertedVideoFile
@@ -20,10 +19,10 @@ from .video_file import (
     is_audio_stream_source,
 )
 
-StreamSourceForAudioReEncoding = Union[
-    StreamSource[VideoStream, Literal["copied"]],
-    StreamSource[AudioStream, Literal["copied", "converted"]],
-]
+StreamSourceForAudioReEncoding = (
+    StreamSource[VideoStream, Literal["copied"]]
+    | StreamSource[AudioStream, Literal["copied", "converted"]]
+)
 
 
 class StreamSourcesForAudioReEncoding(StreamSources):

--- a/ts2mp4/cli.py
+++ b/ts2mp4/cli.py
@@ -4,7 +4,7 @@ import datetime
 import platform
 from enum import Enum
 from pathlib import Path
-from typing import Annotated, Union
+from typing import Annotated
 
 import logzero
 import typer
@@ -46,7 +46,7 @@ def main(
         Path, typer.Argument(exists=True, file_okay=True, dir_okay=False, readable=True)
     ],
     log_file: Annotated[
-        Union[Path, None],
+        Path | None,
         typer.Option(
             help="Path to the log file. Defaults to <input_file>.log",
             file_okay=True,

--- a/ts2mp4/initial_converter.py
+++ b/ts2mp4/initial_converter.py
@@ -1,10 +1,9 @@
 """Handles the initial conversion from TS to MP4."""
 
 from pathlib import Path
-from typing import Literal, Union
+from typing import Literal, Self
 
 from pydantic import model_validator
-from typing_extensions import Self
 
 from .ffmpeg import execute_ffmpeg
 from .media_info import AudioStream, VideoStream
@@ -15,10 +14,10 @@ from .video_file import (
     VideoFile,
 )
 
-StreamSourceForInitialConversion = Union[
-    StreamSource[VideoStream, Literal["converted"]],
-    StreamSource[AudioStream, Literal["copied"]],
-]
+StreamSourceForInitialConversion = (
+    StreamSource[VideoStream, Literal["converted"]]
+    | StreamSource[AudioStream, Literal["copied"]]
+)
 
 
 class StreamSourcesForInitialConversion(StreamSources):

--- a/ts2mp4/media_info.py
+++ b/ts2mp4/media_info.py
@@ -3,7 +3,7 @@
 import json
 from functools import cache
 from pathlib import Path
-from typing import Any, Literal, Optional, Union
+from typing import Any, Literal, Optional
 
 from pydantic import BaseModel, ConfigDict, Field, field_validator
 
@@ -40,7 +40,7 @@ class OtherStream(BaseStream):
     """A class to hold information about other stream types."""
 
 
-Stream = Union[VideoStream, AudioStream, OtherStream]
+Stream = VideoStream | AudioStream | OtherStream
 
 
 class Format(BaseModel):
@@ -61,7 +61,7 @@ class MediaInfo(BaseModel):
 
     @field_validator("streams", mode="before")
     @classmethod
-    def sort_streams(cls, v: Any) -> Union[list[Any], Any]:
+    def sort_streams(cls, v: Any) -> list[Any] | Any:
         """Sorts a list of streams by their index."""
         if v is not None and isinstance(v, list):
             return sorted(

--- a/ts2mp4/video_file.py
+++ b/ts2mp4/video_file.py
@@ -1,9 +1,14 @@
 """A module for the VideoFile class."""
 
-from typing import Generic, Iterator, Literal, TypeVar
+from typing import Generic, Iterator, Literal, TypeGuard, TypeVar
 
-from pydantic import BaseModel, ConfigDict, FilePath, RootModel, model_validator
-from typing_extensions import TypeGuard
+from pydantic import (
+    BaseModel,
+    ConfigDict,
+    FilePath,
+    RootModel,
+    model_validator,
+)
 
 from .media_info import AudioStream, MediaInfo, Stream, VideoStream, get_media_info
 


### PR DESCRIPTION
Updates the codebase to use modern type hinting syntax available in Python 3.12 and later.

The following changes were made:
- Replaced `Union[X, Y]` with the `X | Y` operator for expressing type unions.
- Migrated imports from `typing_extensions` to `typing` for `Self` and `TypeGuard`, which are now available in the standard library.