### PR TITLE
refactor(hashing): Modernize stream hashing logic and improve type safety

### DIFF
--- a/tests/test_stream_integrity.py
+++ b/tests/test_stream_integrity.py
@@ -202,7 +202,7 @@ def test_verify_copied_streams_no_copied_streams(
 def test_verify_copied_streams_unknown_stream_type(
     mocker: MockerFixture, mock_converted_video_file: MagicMock
 ) -> None:
-    """Tests that a RuntimeError is raised with "Unknown" for a missing stream type."""
+    """Tests that a NotImplementedError is raised for an unsupported stream type."""
     mocker.patch("ts2mp4.stream_integrity.compare_stream_hashes", return_value=False)
     streams = list(mock_converted_video_file.media_info.streams)
     streams[1] = OtherStream(index=1, codec_type="unknown")
@@ -215,10 +215,10 @@ def test_verify_copied_streams_unknown_stream_type(
         )
     )
 
-    with pytest.raises(RuntimeError) as excinfo:
+    with pytest.raises(NotImplementedError) as excinfo:
         verify_copied_streams(mock_converted_video_file)
 
     assert (
-        "unknown stream integrity check failed for stream at index 1"
-        in str(excinfo.value).lower()
+        "Stream integrity check for non-audio/video streams is not implemented."
+        in str(excinfo.value)
     )

--- a/ts2mp4/audio_reencoder.py
+++ b/ts2mp4/audio_reencoder.py
@@ -99,6 +99,13 @@ def _build_stream_sources_for_audio_re_encoding(
             )
 
         if original_stream.codec_type == "video":
+            if not isinstance(matching_stream, VideoStream):
+                raise RuntimeError(
+                    f"Mismatch in stream types for file {encoded_file.path.name}: "
+                    f"Stream at index {matching_stream.index} was expected to be 'video', "
+                    f"but was '{matching_stream.codec_type}'."
+                )
+
             # Video streams should be always copied from the encoded file
             stream_sources_list.append(
                 StreamSource(
@@ -108,6 +115,13 @@ def _build_stream_sources_for_audio_re_encoding(
                 )
             )
         elif original_stream.codec_type == "audio":
+            if not isinstance(matching_stream, AudioStream):
+                raise RuntimeError(
+                    f"Mismatch in stream types for file {encoded_file.path.name}: "
+                    f"Stream at index {matching_stream.index} was expected to be 'audio', "
+                    f"but was '{matching_stream.codec_type}'."
+                )
+
             if compare_stream_hashes(
                 input_video=original_file,
                 output_video=encoded_file,

--- a/ts2mp4/stream_integrity.py
+++ b/ts2mp4/stream_integrity.py
@@ -3,15 +3,15 @@
 from logzero import logger
 
 from .hashing import get_stream_md5
-from .media_info import Stream
+from .media_info import AudioStream, VideoStream
 from .video_file import ConvertedVideoFile, VideoFile
 
 
 def compare_stream_hashes(
     input_video: VideoFile,
     output_video: VideoFile,
-    input_stream: "Stream",
-    output_stream: "Stream",
+    input_stream: VideoStream | AudioStream,
+    output_stream: VideoStream | AudioStream,
 ) -> bool:
     """Check the integrity of a single stream by comparing MD5 hashes.
 
@@ -61,6 +61,13 @@ def verify_copied_streams(converted_file: ConvertedVideoFile) -> None:
     for output_stream, stream_source in converted_file.stream_with_sources:
         if stream_source.conversion_type != "copied":
             continue
+
+        if not isinstance(output_stream, (AudioStream, VideoStream)) or not isinstance(
+            stream_source.source_stream, (AudioStream, VideoStream)
+        ):
+            raise NotImplementedError(
+                "Stream integrity check for non-audio/video streams is not implemented."
+            )
 
         if not compare_stream_hashes(
             input_video=VideoFile(path=stream_source.source_video_path),

--- a/ts2mp4/video_file.py
+++ b/ts2mp4/video_file.py
@@ -2,13 +2,7 @@
 
 from typing import Generic, Iterator, Literal, TypeGuard, TypeVar
 
-from pydantic import (
-    BaseModel,
-    ConfigDict,
-    FilePath,
-    RootModel,
-    model_validator,
-)
+from pydantic import BaseModel, ConfigDict, FilePath, RootModel, model_validator
 
 from .media_info import AudioStream, MediaInfo, Stream, VideoStream, get_media_info
 
@@ -58,7 +52,7 @@ class VideoFile(BaseModel):
         )
 
     @property
-    def valid_streams(self) -> tuple[Stream, ...]:
+    def valid_streams(self) -> tuple[VideoStream | AudioStream, ...]:
         """Return a tuple of valid streams."""
         return self.valid_video_streams + self.valid_audio_streams
 


### PR DESCRIPTION
This commit introduces several improvements to the stream hashing module and enhances type safety across related modules:

- Replaces the conditional if/elif structure for selecting the output format with a more expressive `match` statement.
- Removes unused `_mtime` and `_size` parameters from `_get_stream_md5_async` and `_get_stream_md5_cached`, simplifying the function signatures.
- Improves type hinting by using `VideoStream | AudioStream` and `assert_never` for better static analysis and exhaustiveness checking.
- Adds a detailed docstring to `_get_stream_md5_cached` to explain the caching strategy.
- Refines type hints and adds type checks in `stream_integrity.py` and `audio_reencoder.py` to resolve mypy errors.
- Modifies `stream_integrity.py` to raise `NotImplementedError` for unsupported stream types during integrity checks, providing clearer error semantics.
- Implements `RuntimeError` with detailed messages for stream type mismatches in `audio_reencoder.py`, improving diagnostic information.
- Adds a comprehensive parameterized test in `tests/test_audio_reencoder.py` to cover stream type mismatch scenarios.
