### PR TITLE
Refactor: `stream_with_sources` to return `StreamWithSource` model

### DIFF
--- a/tests/test_stream_integrity.py
+++ b/tests/test_stream_integrity.py
@@ -13,6 +13,7 @@ from ts2mp4.video_file import (
     ConvertedVideoFile,
     StreamSource,
     StreamSources,
+    StreamWithSource,
     VideoFile,
 )
 
@@ -138,9 +139,13 @@ def mock_converted_video_file(
 
     # MagicMock doesn't automatically handle properties that are generators
     type(mock_converted_file).stream_with_sources = mocker.PropertyMock(
-        return_value=zip(
-            mock_converted_file.media_info.streams, mock_converted_file.stream_sources
-        )
+        return_value=[
+            StreamWithSource(stream=stream, source=source)
+            for stream, source in zip(
+                mock_converted_file.media_info.streams,
+                mock_converted_file.stream_sources,
+            )
+        ]
     )
 
     return mock_converted_file
@@ -187,10 +192,13 @@ def test_verify_copied_streams_no_copied_streams(
     mock_converted_video_file.stream_sources = StreamSources(root=tuple(stream_sources))
 
     type(mock_converted_video_file).stream_with_sources = mocker.PropertyMock(
-        return_value=zip(
-            mock_converted_video_file.media_info.streams,
-            mock_converted_video_file.stream_sources,
-        )
+        return_value=[
+            StreamWithSource(stream=stream, source=source)
+            for stream, source in zip(
+                mock_converted_video_file.media_info.streams,
+                mock_converted_video_file.stream_sources,
+            )
+        ]
     )
 
     verify_copied_streams(mock_converted_video_file)
@@ -209,10 +217,13 @@ def test_verify_copied_streams_unknown_stream_type(
     mock_converted_video_file.media_info = MediaInfo(streams=tuple(streams))
 
     type(mock_converted_video_file).stream_with_sources = mocker.PropertyMock(
-        return_value=zip(
-            mock_converted_video_file.media_info.streams,
-            mock_converted_video_file.stream_sources,
-        )
+        return_value=[
+            StreamWithSource(stream=stream, source=source)
+            for stream, source in zip(
+                mock_converted_video_file.media_info.streams,
+                mock_converted_video_file.stream_sources,
+            )
+        ]
     )
 
     with pytest.raises(NotImplementedError) as excinfo:

--- a/ts2mp4/quality_check.py
+++ b/ts2mp4/quality_check.py
@@ -75,14 +75,17 @@ async def get_audio_quality_metrics(
     """
     quality_metrics: dict[int, AudioQualityMetrics] = {}
 
-    for stream, stream_source in converted_file.stream_with_sources:
-        if stream.codec_type != "audio" or stream_source.conversion_type != "converted":
+    for stream_with_source in converted_file.stream_with_sources:
+        if (
+            stream_with_source.stream.codec_type != "audio"
+            or stream_with_source.source.conversion_type != "converted"
+        ):
             continue
 
-        original_file = stream_source.source_video_path
+        original_file = stream_with_source.source.source_video_path
         re_encoded_file = converted_file.path
-        original_stream_index = stream_source.source_stream.index
-        re_encoded_stream_index = stream.index
+        original_stream_index = stream_with_source.source.source_stream.index
+        re_encoded_stream_index = stream_with_source.stream.index
 
         command = [
             "-hide_banner",

--- a/ts2mp4/stream_integrity.py
+++ b/ts2mp4/stream_integrity.py
@@ -58,27 +58,29 @@ def verify_copied_streams(converted_file: ConvertedVideoFile[StreamSources]) -> 
     """
     logger.info(f"Verifying copied stream integrity for {converted_file.path.name}")
 
-    for output_stream, stream_source in converted_file.stream_with_sources:
-        if stream_source.conversion_type != "copied":
+    for stream_with_source in converted_file.stream_with_sources:
+        if stream_with_source.source.conversion_type != "copied":
             continue
 
-        if not isinstance(output_stream, (AudioStream, VideoStream)) or not isinstance(
-            stream_source.source_stream, (AudioStream, VideoStream)
+        if not isinstance(
+            stream_with_source.stream, (AudioStream, VideoStream)
+        ) or not isinstance(
+            stream_with_source.source.source_stream, (AudioStream, VideoStream)
         ):
             raise NotImplementedError(
                 "Stream integrity check for non-audio/video streams is not implemented."
             )
 
         if not compare_stream_hashes(
-            input_video=VideoFile(path=stream_source.source_video_path),
+            input_video=VideoFile(path=stream_with_source.source.source_video_path),
             output_video=converted_file,
-            input_stream=stream_source.source_stream,
-            output_stream=output_stream,
+            input_stream=stream_with_source.source.source_stream,
+            output_stream=stream_with_source.stream,
         ):
-            stream_type = output_stream.codec_type or "Unknown"
+            stream_type = stream_with_source.stream.codec_type or "Unknown"
             raise RuntimeError(
                 f"{stream_type.capitalize()} stream integrity check "
-                f"failed for stream at index {stream_source.source_stream.index}"
+                f"failed for stream at index {stream_with_source.source.source_stream.index}"
             )
 
     logger.info("Copied stream integrity verified successfully. All MD5 hashes match.")


### PR DESCRIPTION
Introduces a new Pydantic model `StreamWithSource` to provide a more explicit and type-safe data structure for associating a media stream with its source information.

The `ConvertedVideoFile.stream_with_sources` method has been refactored to return an iterator of `StreamWithSource` objects. This change improves code clarity, as consumers of the method now receive a self-documenting object instead of a tuple.

The new implementation of `stream_with_sources` leverages a `match` statement for robust type handling and includes `assert_never` to ensure exhaustive static analysis. It also raises a `RuntimeError` if a mismatch is detected between an output stream's type and its corresponding source stream's type, preventing potential downstream errors. A new unit test verifies this error-handling behavior.

All dependent application code (`quality_check.py`, `stream_integrity.py`) and their corresponding tests have been updated to work with the new `StreamWithSource` object.